### PR TITLE
Search the full path

### DIFF
--- a/SkeinPyPy_NewUI/newui/skeinRun.py
+++ b/SkeinPyPy_NewUI/newui/skeinRun.py
@@ -7,20 +7,20 @@ from skeinforge_application.skeinforge_utilities import skeinforge_craft
 def getPyPyExe():
 	"Return the path to the pypy executable if we can find it. Else return False"
 	if platform.system() == "Windows":
+		exeName = "pypy.exe"
 		pypyExe = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../pypy/pypy.exe"));
 	else:
+		exeName = "pypy"
 		pypyExe = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../pypy/bin/pypy"));
 	if os.path.exists(pypyExe):
 		return pypyExe
-	pypyExe = "/bin/pypy";
-	if os.path.exists(pypyExe):
-		return pypyExe
-	pypyExe = "/usr/bin/pypy";
-	if os.path.exists(pypyExe):
-		return pypyExe
-	pypyExe = "/usr/local/bin/pypy";
-	if os.path.exists(pypyExe):
-		return pypyExe
+
+	path = os.environ['PATH']
+	paths = path.split(os.pathsep)
+	for p in paths:
+		pypyExe = os.path.join(p, exeName)
+		if os.path.exists(pypyExe):
+			return pypyExe 
 	return False
 
 def runSkein(fileNames):


### PR DESCRIPTION
I had tried putting a link to my pypy executable in ~/bin/pypy, which is on my path, but then realized it wasn't searching all of the path.  This change should look in all directories on the path.  Tested to work on linux, but should also work on windows, though I'm unable to test this.
