### PR TITLE
Build osx printrun clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.tar.bz2
+*.tar.gz
+osx64-SkeinPyPy-NewUI*
+Printrun

--- a/build.sh
+++ b/build.sh
@@ -82,9 +82,14 @@ else
 fi
 
 #Get our own version of Printrun
-rm -rf Printrun
-git clone git://github.com/daid/Printrun.git
-rm -rf Printrun/.git
+if [ ! -d "Printrun" ]; then
+  git clone git://github.com/daid/Printrun.git
+else
+  echo "Updating Printrun"
+  cd Printrun
+  git pull
+  cd ..
+fi
 
 #############################
 # Build the packages
@@ -135,7 +140,8 @@ rm -rf ${TARGET_DIR}/pypy/lib-python/2.7/test
 cp -a SkeinPyPy_NewUI ${TARGET_DIR}/SkeinPyPy
 
 #add printrun
-mv Printrun ${TARGET_DIR}/Printrun
+cp -a Printrun ${TARGET_DIR}/Printrun
+rm -rf ${TARGET_DIR}/Printrun/.git*
 
 #add script files
 if [ $BUILD_TARGET = "win32" ]; then


### PR DESCRIPTION
Hi daid,

I've modified the build script to use `git update` for Printrun instead of cloning the entire repository on each build.

Hope it'll save you some build time for more nice features in SkeinPyPy :)

Alex
