### PR TITLE
Ultimaker Checkup wizard fails to fail correctly due to missing sys import

### DIFF
--- a/Cura/newui/machineCom.py
+++ b/Cura/newui/machineCom.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import __init__
 
-import os, glob, wx, threading
+import os, glob, wx, threading, sys
 
 from serial import Serial
 


### PR DESCRIPTION
Added sys import so that the wizard produces a meaningful error message instead of crashing when it can't find the right serial settings.
