### PR TITLE
Probably fixes #17 issue and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ linux-Cura-*
 Printrun
 .idea
 .DS_Store
+Cura/current_profile.ini
+Cura/preferences.ini
+cura.sh

--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -302,10 +302,10 @@ class mainWindow(configBase.configWindowBase):
 		newSize = self.GetSize();
 		newSize.IncBy(0, -spp.GetSize().GetHeight())
 		self.SetSize(newSize)
-		self.sizer.Remove(spp)
-		spp.Destroy()
+		spp.Show(False)
+		self.sizer.Detach(spp)
 		for spp in self.progressPanelList:
-			self.sizer.Remove(spp)
+			self.sizer.Detach(spp)
 		i = 2
 		for spp in self.progressPanelList:
 			self.sizer.Add(spp, (i,0), span=(1,4), flag=wx.EXPAND)


### PR DESCRIPTION
On OSX spp.Destroy() causes an segfault, sizer.Remove(app) removes app
from the form but tries to call spp.Destroy() afterwards.
By hiding and detaching I created a workaround for the OSX problem.
This solution needs testing on Windows and Linux.
