### PR TITLE
Fixes #49 issue

### DIFF
--- a/Cura/gui/printWindow.py
+++ b/Cura/gui/printWindow.py
@@ -105,7 +105,8 @@ class printWindow(wx.Frame):
 			status += 'Line: %d/%d\n' % (self.printIdx, len(self.gcodeList))
 		if self.temp != None:
 			status += 'Temp: %d\n' % (self.temp)
-		self.statsText.SetLabel(status)
+		self.statsText.SetLabel(status.strip())
+		self.Layout()
 	
 	def OnConnect(self, e):
 		if self.machineCom != None:


### PR DESCRIPTION
Calling self.Layout() after changing the static text fixes text going
outside the box.
Needs to be checked on Linux and Windows.
