### PR TITLE
Empty scale defaults to scale 1.0

### DIFF
--- a/Cura/gui/preview3d.py
+++ b/Cura/gui/preview3d.py
@@ -131,7 +131,12 @@ class previewPanel(wx.Panel):
 		self.OnScale(None)
 
 	def OnScale(self, e):
-		profile.putProfileSetting('model_scale', self.scale.GetValue())
+		scale = 1.0
+		if self.scale.GetValue() != '':
+			scale = float(self.scale.GetValue())
+			if scale <= 0.0:
+				scale = 1.0
+		profile.putProfileSetting('model_scale', scale)
 		self.updateModelTransform()
 	
 	def OnScaleMax(self, e):


### PR DESCRIPTION
When the input field of the scale is empty the model disappears.
By defaulting to 1.0 when the field is empty or negative value the model remains shown.
You don't get the illusion the model is gone.
