### PR TITLE
Fix for #73: When start.gcode is changed changes are not saved

### DIFF
--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -322,7 +322,7 @@ def setAlterationFile(filename, value):
 	if not globalProfileParser.has_section('alterations'):
 		globalProfileParser.add_section('alterations')
 	globalProfileParser.set('alterations', filename, value.encode("utf-8"))
-	saveGlobalProfile(profile.getDefaultProfilePath())
+	saveGlobalProfile(getDefaultProfilePath())
 
 ### Get the alteration file for output. (Used by Skeinforge)
 def getAlterationFileContents(filename):


### PR DESCRIPTION
This changes the call to match the others in the same file and seems to fix the issue on my machine.
