### PR TITLE
Fix version detection for all Python versions 

### DIFF
--- a/Cura/cura_sf/fabmetheus_utilities/euclidean.py
+++ b/Cura/cura_sf/fabmetheus_utilities/euclidean.py
@@ -37,7 +37,7 @@ import sys
 import math
 import random
 
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
 	import cStringIO
 else:
 	import io as cStringIO

--- a/Cura/cura_sf/fabmetheus_utilities/gcodec.py
+++ b/Cura/cura_sf/fabmetheus_utilities/gcodec.py
@@ -29,7 +29,7 @@ import os
 import sys
 import traceback
 
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
 	import cStringIO
 else:
 	import io as cStringIO

--- a/Cura/cura_sf/fabmetheus_utilities/xml_simple_writer.py
+++ b/Cura/cura_sf/fabmetheus_utilities/xml_simple_writer.py
@@ -10,7 +10,7 @@ import __init__
 
 import sys
 
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
 	import cStringIO
 else:
 	import io as cStringIO

--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -4,7 +4,7 @@ from __future__ import division
 import __init__
 
 import os, traceback, math, re, zlib, base64, time, sys
-if sys.version_info.major < 3:
+if sys.version_info[0] < 3:
 	import ConfigParser
 else:
 	import configparser as ConfigParser


### PR DESCRIPTION
Inspecting sys.version_info using named component attributes was added in
the patch "Some fixes to start support for python3."

Named component attributes were only added to sys.version_info in Python
2.7 so their use breaks Cura for Python 2.6.

As Cura otherwise works in the still widely used Python 2.6 it seems best
to maintain this compatibility.
