### PR TITLE
Allow cancelling the automatic installation of dependencies

### DIFF
--- a/scripts/osx64/Cura.app/Contents/MacOS/Cura
+++ b/scripts/osx64/Cura.app/Contents/MacOS/Cura
@@ -11,12 +11,22 @@ fi
 
 displayMessage()
 {
-	/usr/bin/osascript > /dev/null <<-EOF
+	/usr/bin/osascript > /dev/null << EOF
 tell application "System Events"
 	activate
-	display dialog "$@" buttons {"Ok"}
+  set question to display dialog "$@"
+end tell
+return button returned of question
+EOF
+  if [ $? != 0 ]; then
+    /usr/bin/osascript > /dev/null << EOF
+tell application "System Events"
+	activate
+  display dialog "User Cancelled Install" buttons {"Ok"}
 end tell
 EOF
+    exit 1
+  fi
 }
 
 #Testing for python2.7, which we need and is not always installed on MacOS 1.6


### PR DESCRIPTION
When I saw wxpython was a dependency and Cura was going to install it, I got worried it would pollute my environment. So I manually killed wxpython and installed via homebrew. Now there is a cancel option for all the display messages that will exit the installer if the user clicks it. Not sure if this is more confusing or more helpful, so if other people chimed in that would be cool.
