### PR TITLE
Fixed SD card eject under Windows

### DIFF
--- a/Cura/gui/sliceProgessPanel.py
+++ b/Cura/gui/sliceProgessPanel.py
@@ -86,7 +86,7 @@ class sliceProgessPanel(wx.Panel):
 	
 	def OnSafeRemove(self):
 		if platform.system() == "Windows":
-			cmd = "%s %s>NUL" % (os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'EjectMedia.exe')), profile.getPreference('sdpath'))
+			cmd = '"%s" %s>NUL' % (os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'EjectMedia.exe')), profile.getPreference('sdpath'))
 		elif platform.system() == "Darwin":
 			cmd = "diskutil eject '%s' > /dev/null 2>&1" % (profile.getPreference('sdpath'))
 		else:


### PR DESCRIPTION
Path to EjectMedia.exe needed to be quotes since it typically contains
spaces
