### PR TITLE
Dynamic number of left hand columns

### DIFF
--- a/Cura/gui/configBase.py
+++ b/Cura/gui/configBase.py
@@ -30,10 +30,12 @@ class configPanelBase(wx.Panel):
 		configPanel = wx.Panel(parent);
 		leftConfigPanel = wx.Panel(configPanel)
 		rightConfigPanel = wx.Panel(configPanel)
+
 		sizer = wx.GridBagSizer(2, 2)
 		leftConfigPanel.SetSizer(sizer)
 		sizer = wx.GridBagSizer(2, 2)
 		rightConfigPanel.SetSizer(sizer)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
 		configPanel.SetSizer(sizer)
 		sizer.Add(leftConfigPanel, border=35, flag=wx.RIGHT)
@@ -42,28 +44,34 @@ class configPanelBase(wx.Panel):
 		rightConfigPanel.main = self
 		return leftConfigPanel, rightConfigPanel, configPanel
 
-	def CreateSimpleConfigTab(self, nb, name):
-		leftConfigPanel, configPanel = self.CreateSimpleConfigPanel(nb)
-		nb.AddPage(configPanel, name)
-		return leftConfigPanel
-	
-	def CreateSimpleConfigPanel(self, parent):
-		configPanel = wx.lib.scrolledpanel.ScrolledPanel(parent)
+	def CreateDynamicConfigTab(self, nb, name):
+		configPanel = wx.lib.scrolledpanel.ScrolledPanel(nb)	
+		#configPanel = wx.Panel(nb);
 		leftConfigPanel = wx.Panel(configPanel)
-		
+		rightConfigPanel = wx.Panel(configPanel)
+
 		sizer = wx.GridBagSizer(2, 2)
 		leftConfigPanel.SetSizer(sizer)
 		sizer.AddGrowableCol(1)
 
+		sizer = wx.GridBagSizer(2, 2)
+		rightConfigPanel.SetSizer(sizer)
+		sizer.AddGrowableCol(1)
+
 		sizer = wx.BoxSizer(wx.HORIZONTAL)
+		sizer.Add(leftConfigPanel, proportion=1, border=35, flag=wx.EXPAND)
+		sizer.Add(rightConfigPanel, proportion=1, flag=wx.EXPAND)
 		configPanel.SetSizer(sizer)
-		sizer.Add(leftConfigPanel, 1, wx.EXPAND)
 
 		configPanel.SetAutoLayout(1)
-		configPanel.SetupScrolling()
+		configPanel.SetupScrolling(scroll_x=False, scroll_y=True)
 
 		leftConfigPanel.main = self
-		return leftConfigPanel, configPanel
+		rightConfigPanel.main = self
+
+		nb.AddPage(configPanel, name)
+
+		return leftConfigPanel, rightConfigPanel, configPanel
 
 	def OnPopupDisplay(self, setting):
 		self.popup.setting = setting
@@ -99,6 +107,32 @@ class configPanelBase(wx.Panel):
 				setting.SetValue(profile.getPreference(setting.configName))
 		self.Update()
 
+	def XXXgetLabelColumnWidth(self):
+		maxWidth = 0
+		for setting in self.settingControlList:
+			maxWidth = max(maxWidth, setting.label.GetWidth())
+
+	def XXXsetLabelColumnWidth(self, newWidth):
+		for setting in self.settingControlList:
+			setting.label.SetWidth(newWidth)			
+
+	def getLabelColumnWidth(self, panel):
+		maxWidth = 0
+		for child in panel.GetChildren():
+			if isinstance(child, wx.lib.stattext.GenStaticText):
+				maxWidth = max(maxWidth, child.GetSize()[0])
+		return maxWidth
+	
+	def setLabelColumnWidth(self, panel, width):
+		for child in panel.GetChildren():
+			if isinstance(child, wx.lib.stattext.GenStaticText):
+				size = child.GetSize()
+				size[0] = width
+				#child.SetSize(size)
+				child.SetBestSize(size)
+				#child.GetContainingSizer().Layout()
+				#child.SetBackgroundColour('Green')
+	
 class TitleRow():
 	def __init__(self, panel, name):
 		"Add a title row to the configuration panel"
@@ -150,6 +184,11 @@ class SettingRow():
 			self.ctrl.Bind(wx.EVT_LEFT_DOWN, self.OnMouseExit)
 			flag = wx.EXPAND
 
+		# Set the minimum size of control to something other than the humungous default
+		minSize = self.ctrl.GetMinSize()
+		minSize[0] = 50
+		self.ctrl.SetMinSize(minSize)
+		
 		sizer.Add(self.label, (x,y), flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT,border=10)
 		sizer.Add(self.ctrl, (x,y+1), flag=wx.ALIGN_BOTTOM|flag)
 		sizer.SetRows(x+1)

--- a/Cura/gui/configBase.py
+++ b/Cura/gui/configBase.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import platform
 import wx, wx.lib.stattext, types
 
 from Cura.util import validators
@@ -69,6 +70,9 @@ class configPanelBase(wx.Panel):
 		leftConfigPanel.main = self
 		rightConfigPanel.main = self
 
+		configPanel.leftPanel = leftConfigPanel
+		configPanel.rightPanel = rightConfigPanel
+
 		nb.AddPage(configPanel, name)
 
 		return leftConfigPanel, rightConfigPanel, configPanel
@@ -107,15 +111,6 @@ class configPanelBase(wx.Panel):
 				setting.SetValue(profile.getPreference(setting.configName))
 		self.Update()
 
-	def XXXgetLabelColumnWidth(self):
-		maxWidth = 0
-		for setting in self.settingControlList:
-			maxWidth = max(maxWidth, setting.label.GetWidth())
-
-	def XXXsetLabelColumnWidth(self, newWidth):
-		for setting in self.settingControlList:
-			setting.label.SetWidth(newWidth)			
-
 	def getLabelColumnWidth(self, panel):
 		maxWidth = 0
 		for child in panel.GetChildren():
@@ -128,10 +123,7 @@ class configPanelBase(wx.Panel):
 			if isinstance(child, wx.lib.stattext.GenStaticText):
 				size = child.GetSize()
 				size[0] = width
-				#child.SetSize(size)
 				child.SetBestSize(size)
-				#child.GetContainingSizer().Layout()
-				#child.SetBackgroundColour('Green')
 	
 class TitleRow():
 	def __init__(self, panel, name):
@@ -186,7 +178,12 @@ class SettingRow():
 
 		# Set the minimum size of control to something other than the humungous default
 		minSize = self.ctrl.GetMinSize()
-		minSize[0] = 50
+		
+		if platform.system() == "Darwin":		
+			# Under MacOS, it appears that the minSize is used for the actual size...
+			minSize[0] = 150
+		else:
+			minSize[0] = 50
 		self.ctrl.SetMinSize(minSize)
 		
 		sizer.Add(self.label, (x,y), flag=wx.ALIGN_CENTER_VERTICAL|wx.LEFT,border=10)

--- a/Cura/gui/configBase.py
+++ b/Cura/gui/configBase.py
@@ -179,8 +179,8 @@ class SettingRow():
 		# Set the minimum size of control to something other than the humungous default
 		minSize = self.ctrl.GetMinSize()
 		
-		if platform.system() == "Darwin":		
-			# Under MacOS, it appears that the minSize is used for the actual size...
+		if platform.system() == "Darwin":
+			# Under MacOS, it appears that the minSize is used for the actual size, so give the field a bit more room...
 			minSize[0] = 150
 		else:
 			minSize[0] = 50

--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -608,11 +608,7 @@ class normalSettingsPanel(configBase.configPanelBase):
 		c = configBase.SettingRow(right, "Packing Density", 'filament_density', '1.00', 'Packing density of your filament. This should be 1.00 for PLA and 0.85 for ABS')
 		validators.validFloat(c, 0.5, 1.5)
 
-		leftWidth = self.getLabelColumnWidth(left)
-		rightWidth = self.getLabelColumnWidth(right)
-		maxWidth = max(leftWidth, rightWidth)
-		self.setLabelColumnWidth(left, maxWidth)
-		self.setLabelColumnWidth(right, maxWidth)
+		self.SizeLabelWidths(left, right)
 		
 		(left, right, self.advancedPanel) = self.CreateDynamicConfigTab(self.nb, 'Advanced config')
 		
@@ -656,6 +652,8 @@ class normalSettingsPanel(configBase.configPanelBase):
 		validators.warningAbove(c, lambda : (float(profile.getProfileSetting('nozzle_size')) * 3.0 / 4.0), "A bottom layer of more then %.2fmm (3/4 nozzle size) usually give bad results and is not recommended.")
 		c = configBase.SettingRow(right, "Duplicate outlines", 'enable_skin', False, 'Skin prints the outer lines of the prints twice, each time with half the thickness. This gives the illusion of a higher print quality.')
 
+		self.SizeLabelWidths(left, right)
+
 		#Plugin page
 		self.pluginPanel = pluginPanel.pluginPanel(self.nb)
 		if len(self.pluginPanel.pluginList) > 0:
@@ -668,6 +666,13 @@ class normalSettingsPanel(configBase.configPanelBase):
 		self.nb.AddPage(self.alterationPanel, "Start/End-GCode")
 
 		self.Bind(wx.EVT_SIZE, self.OnSize)
+
+	def SizeLabelWidths(self, left, right):
+		leftWidth = self.getLabelColumnWidth(left)
+		rightWidth = self.getLabelColumnWidth(right)
+		maxWidth = max(leftWidth, rightWidth)
+		self.setLabelColumnWidth(left, maxWidth)
+		self.setLabelColumnWidth(right, maxWidth)
 
 	def OnSize(self, e):
 		# Make the size of the Notebook control the same size as this control

--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -692,10 +692,10 @@ class normalSettingsPanel(configBase.configPanelBase):
 		#         switch to horizontal
 		#
 				
-		col1 = configPanel.Children[0]
+		col1 = configPanel.leftPanel
 		colSize1 = col1.GetSize()
 		colBestSize1 = col1.GetBestSize()
-		col2 = configPanel.Children[1]
+		col2 = configPanel.rightPanel
 		colSize2 = col2.GetSize()
 		colBestSize2 = col2.GetBestSize()
 
@@ -705,8 +705,8 @@ class normalSettingsPanel(configBase.configPanelBase):
 			if (colSize1[0] <= colBestSize1[0]) or (colSize2[0] <= colBestSize2[0]):
 				configPanel.Freeze()
 				sizer = wx.BoxSizer(wx.VERTICAL)
-				sizer.Add(configPanel.Children[0], flag=wx.EXPAND)
-				sizer.Add(configPanel.Children[1], flag=wx.EXPAND)
+				sizer.Add(configPanel.leftPanel, flag=wx.EXPAND)
+				sizer.Add(configPanel.rightPanel, flag=wx.EXPAND)
 				configPanel.SetSizer(sizer)
 				#sizer.Layout()
 				configPanel.Layout()
@@ -716,8 +716,8 @@ class normalSettingsPanel(configBase.configPanelBase):
 			if colSize1[0] > (colBestSize1[0] + colBestSize2[0]):
 				configPanel.Freeze()
 				sizer = wx.BoxSizer(wx.HORIZONTAL)
-				sizer.Add(configPanel.Children[0], proportion=1, border=35, flag=wx.EXPAND)
-				sizer.Add(configPanel.Children[1], proportion=1, flag=wx.EXPAND)
+				sizer.Add(configPanel.leftPanel, proportion=1, border=35, flag=wx.EXPAND)
+				sizer.Add(configPanel.rightPanel, proportion=1, flag=wx.EXPAND)
 				configPanel.SetSizer(sizer)
 				#sizer.Layout()
 				configPanel.Layout()

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Assuming you have virtualenv at *~/.virtualenvs/Cura/* and [wxPython sources](ht
         --enable-universal_binary=i386,x86_64 \
         --enable-webkit \
         --prefix=$HOME/.virtualenvs/Cura/ \
-        --with-expat
+        --with-expat \
         --with-libjpeg=builtin \
         --with-libpng=builtin \
         --with-libtiff=builtin \


### PR DESCRIPTION
This addresses problems identified in issue #338

Updated to dynamically display one or two columns of configuration options on the left hand pane depending on the position of the splitter window slider and available real estate.  

The contents of the columns are smoothly sized under Windows 7 and Ubuntu/Gnome.  Under MacOS 10.8, the data entry fields do not resize which leads to white space because the columns are always the same size.  

Changing the behavior on the Mac is not critical but should be eventually fixed (if possible).

One feature that could be implemented (that would also work around the MacOS issue) is to have it that if you double-click on the splitter bar the display switches between 1 or two columns.  A potential problem with this is that what an ideal column width is subjective (user preference), language dependent and changes with the updates to the options panel.
