### PR TITLE
WXVersion selection to avoid package conflicts

### DIFF
--- a/Cura/gui/app.py
+++ b/Cura/gui/app.py
@@ -7,6 +7,11 @@ import shutil
 import glob
 import warnings
 
+#Force correct WXVersion 
+#	May not be forward compatible but better than 
+#	millions of $PATH edits
+import wxversion
+wxversion.select('2.8')
 #Only import the _core to save import time
 import wx._core
 


### PR DESCRIPTION
Add wxversion selection to avoid multi-packag (2.6/2.8) problems found on Ubuntu 12.10

First 'official' patch so be gentle with me :smile: 
