### PR TITLE
Fixed errors in Debian packaging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Packaging
 Cura development comes with a script "package.sh", this script has been designed to run under unix like OSes (Linux, MacOS). Running it from sygwin is not a priority.
 The "package.sh" script generates a final release package. You should not need it during development, unless you are changing the release process. If you want to distribute your own version of Cura, then the package.sh script will allow you to do that.
 
+Debian and Ubuntu Linux
+--------
+
+To build and install Cura, run the following commands:
+
+```bash
+git clone https://github.com/daid/Cura.git
+
+sudo apt-get install python-opengl
+sudo apt-get install python-numpy
+sudo apt-get install python-serial
+sudo apt-get install python-setuptools
+sudo apt-get install cx-freeze
+
+cd Cura
+
+sudo ./package.sh debian
+
+sudo dpkg -i ./scripts/linux/Cura*.deb
+```
 
 Mac OS X
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ PyOpenGL>=3.0.2
 numpy>=1.6.2
 pyserial>=2.6
 power>=1.2
+setuptools>=0.6.34
+cx-freeze>=4.3.1

--- a/scripts/linux/debian/usr/share/applications/cura.desktop
+++ b/scripts/linux/debian/usr/share/applications/cura.desktop
@@ -4,6 +4,7 @@ Name=Cura
 Comment=Cura
 Icon=/usr/share/cura/Cura/resources/images/c.png
 Exec=/usr/bin/python /usr/share/cura/cura.py
+Path=/usr/share/cura/
 StartupNotify=true
 Terminal=false
 Categories=GNOME;GTK;Utility;


### PR DESCRIPTION
Added path to cura.desktop in order to fix slicing errors on Ubuntu, added a few missing perquisites/dependencies that don't appear to be installed by default as of Ubuntu 13.04, and added build/install instructions to the readme.
