### PR TITLE
Add simple output option to command line arguments

### DIFF
--- a/Cura/cura.py
+++ b/Cura/cura.py
@@ -23,6 +23,9 @@ def main():
 		help="Internal option, do not use!")
 	parser.add_option("-s", "--slice", action="store_true", dest="slice",
 		help="Slice the given files instead of opening them in Cura")
+	parser.add_option("-o", "--output", action="store", type="string", dest="output",
+		help="Directory or file to write sliced files to")
+
 	(options, args) = parser.parse_args()
 
 	profile.loadPreferences(profile.getPreferencePath())
@@ -51,8 +54,15 @@ def main():
 			scene.add(m)
 		slicer.runSlicer(scene)
 		slicer.wait()
-		shutil.copyfile(slicer.getGCodeFilename(), args[0] + '.gcode')
-		print 'GCode file saved as: %s' % (args[0] + '.gcode')
+
+		if options.output:
+			print 'output', options.output
+			shutil.copyfile(slicer.getGCodeFilename(), options.output)
+			print 'GCode file saved : %s' % options.output
+		else:
+			shutil.copyfile(slicer.getGCodeFilename(), args[0] + '.gcode')
+			print 'GCode file saved as: %s' % (args[0] + '.gcode')
+
 		slicer.cleanup()
 	else:
 		from Cura.gui import app

--- a/Cura/cura.py
+++ b/Cura/cura.py
@@ -24,7 +24,7 @@ def main():
 	parser.add_option("-s", "--slice", action="store_true", dest="slice",
 		help="Slice the given files instead of opening them in Cura")
 	parser.add_option("-o", "--output", action="store", type="string", dest="output",
-		help="Directory or file to write sliced files to")
+		help="path to write sliced file to")
 
 	(options, args) = parser.parse_args()
 

--- a/Cura/cura.py
+++ b/Cura/cura.py
@@ -56,7 +56,6 @@ def main():
 		slicer.wait()
 
 		if options.output:
-			print 'output', options.output
 			shutil.copyfile(slicer.getGCodeFilename(), options.output)
 			print 'GCode file saved : %s' % options.output
 		else:


### PR DESCRIPTION
Daid,

While working on getting slicing into Octoprint I thought I could add something simple to Cura that would make integrating with it from the command line easier. If you don't want this patch then I'll have to write something that parses the output form calling Cura from the command line and then re-copies the file (which I'd prefer not to do but can if needed). Let me know.
