### PR TITLE
redesign file drop handler: multiple files, directories (recursive)

### DIFF
--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -30,7 +30,8 @@ class mainWindow(wx.Frame):
 
 		wx.EVT_CLOSE(self, self.OnClose)
 
-		self.SetDropTarget(dropTarget.FileDropTarget(self.OnDropFiles, meshLoader.loadSupportedExtensions() + ['.g', '.gcode', '.ini']))
+		# allow dropping any file, restrict later
+		self.SetDropTarget(dropTarget.FileDropTarget(self.OnDropFiles))
 
 		self.normalModeOnlyItems = []
 


### PR DESCRIPTION
Being able to drop a directory allows grouping of files and dropping them together.
Now, you can bundle model files with partial profiles for printing.
You can bundle some features and drop them as a whole.
Dropping a directory loads all files below it (recursively).

This also fixes a regression: dropping multiple files didn't work before.
