### PR TITLE
fix filename when saving gcode

### DIFF
--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -151,7 +151,7 @@ class SceneView(openglGui.glGuiPanel):
 		gcodeFilename = None
 		if len(filenames) == 1:
 			filename = filenames[0]
-			ext = filename[filename.rfind('.'):].lower()
+			ext = os.path.splitext(filename)[1]
 			if ext == '.g' or ext == '.gcode':
 				gcodeFilename = filename
 				mainWindow.addToModelMRU(filename)
@@ -170,7 +170,7 @@ class SceneView(openglGui.glGuiPanel):
 					# directory: queue all included files and directories
 					filenames.extend(os.path.join(filename, f) for f in os.listdir(filename))
 				else:
-					ext = filename[filename.rfind('.'):].lower()
+					ext = os.path.splitext(filename)[1]
 					if ext == '.ini':
 						profile.loadProfile(filename)
 						mainWindow.addToProfileMRU(filename)
@@ -255,8 +255,7 @@ class SceneView(openglGui.glGuiPanel):
 
 	def showSaveGCode(self):
 		dlg=wx.FileDialog(self, _("Save toolpath"), os.path.dirname(profile.getPreference('lastFile')), style=wx.FD_SAVE)
-		filename = self._scene._objectList[0].getName()
-		filename = filename[:filename.rfind('.')] + '.gcode'
+		filename = self._scene._objectList[0].getName() + '.gcode'
 		dlg.SetFilename(filename)
 		dlg.SetWildcard('Toolpath (*.gcode)|*.gcode;*.g')
 		if dlg.ShowModal() != wx.ID_OK:

--- a/Cura/util/mesh.py
+++ b/Cura/util/mesh.py
@@ -16,7 +16,7 @@ class printableObject(object):
 		else:
 			self._name = os.path.basename(originFilename)
 		if '.' in self._name:
-			self._name = self._name[0:self._name.rfind('.')]
+			self._name = os.path.splitext(self._name)[0]
 		self._meshList = []
 		self._position = numpy.array([0.0, 0.0])
 		self._matrix = numpy.matrix([[1,0,0],[0,1,0],[0,0,1]], numpy.float64)

--- a/Cura/util/meshLoader.py
+++ b/Cura/util/meshLoader.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 __copyright__ = "Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License"
 
+import os
+
 from Cura.util.meshLoaders import stl
 from Cura.util.meshLoaders import obj
 from Cura.util.meshLoaders import dae
@@ -27,7 +29,7 @@ def saveWildcardFilter():
 # DAE files are a mess, but they can contain scenes of objects as well as grouped meshes
 
 def loadMeshes(filename):
-	ext = filename[filename.rfind('.'):].lower()
+	ext = os.path.splitext(filename)[1].lower()
 	if ext == '.stl':
 		return stl.loadScene(filename)
 	if ext == '.obj':
@@ -40,7 +42,7 @@ def loadMeshes(filename):
 	return []
 
 def saveMeshes(filename, objects):
-	ext = filename[filename.rfind('.'):].lower()
+	ext = os.path.splitext(filename)[1].lower()
 	if ext == '.stl':
 		stl.saveScene(filename, objects)
 		return


### PR DESCRIPTION
In the proposed filename, the last character was always missing.
Replace some similar string slicing/rfind with splitting.
