### PR TITLE
by default, set extruder to absolute mode

### DIFF
--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -233,6 +233,7 @@ setting('start.gcode', """;Sliced at: {day} {date} {time}
 ;Filament cost: {filament_cost}
 G21        ;metric values
 G90        ;absolute positioning
+M82        ;set extruder to absolute mode
 M107       ;start with the fan off
 
 G28 X0 Y0  ;move X/Y to min endstops


### PR DESCRIPTION
I got a fun, squishy surprise when I switched back to a Cura print after messing around with some custom gocde in relative extrusion mode. Since Cura's slicer assumes that the extruder is in absolute mode, we should make sure to always tell the firmware that is indeed the case.
