### PR TITLE
Add "Reload platform" to refresh all the objects on the platform from their files

### DIFF
--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -57,6 +57,8 @@ class mainWindow(wx.Frame):
 		self.Bind(wx.EVT_MENU, lambda e: self.scene.showLoadModel(), i)
 		i = self.fileMenu.Append(-1, _("Save model...\tCTRL+S"))
 		self.Bind(wx.EVT_MENU, lambda e: self.scene.showSaveModel(), i)
+		i = self.fileMenu.Append(-1, _("Reload platform\tF5"))
+		self.Bind(wx.EVT_MENU, lambda e: self.scene.reloadScene(e), i)
 		i = self.fileMenu.Append(-1, _("Clear platform"))
 		self.Bind(wx.EVT_MENU, lambda e: self.scene.OnDeleteAll(e), i)
 

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -194,6 +194,14 @@ class SceneView(openglGui.glGuiPanel):
 				self._animView = openglGui.animation(self, self._viewTarget.copy(), numpy.array([0,0,0], numpy.float32), 0.5)
 				self._animZoom = openglGui.animation(self, self._zoom, newZoom, 0.5)
 
+	def reloadScene(self, e):
+		# Copy the list before DeleteAll clears it
+		fileList = []
+		for obj in self._scene.objects():
+			fileList.append(obj.getOriginFilename())
+		self.OnDeleteAll(None)
+		self.loadScene(fileList)
+
 	def showLoadModel(self, button = 1):
 		if button == 1:
 			dlg=wx.FileDialog(self, _("Open 3D model"), os.path.split(profile.getPreference('lastFile'))[0], style=wx.FD_OPEN|wx.FD_FILE_MUST_EXIST|wx.FD_MULTIPLE)
@@ -687,6 +695,7 @@ class SceneView(openglGui.glGuiPanel):
 						self.Bind(wx.EVT_MENU, self.OnMergeObjects, menu.Append(-1, _("Dual extrusion merge")))
 					if len(self._scene.objects()) > 0:
 						self.Bind(wx.EVT_MENU, self.OnDeleteAll, menu.Append(-1, _("Delete all objects")))
+						self.Bind(wx.EVT_MENU, self.reloadScene, menu.Append(-1, _("Reload all objects")))
 					if menu.MenuItemCount > 0:
 						self.PopupMenu(menu)
 					menu.Destroy()


### PR DESCRIPTION
Often in the rapid prototyping process I create, slice print, repeat several times until I get the final object I want. In Cura this means deleting all the objects off the platform then adding them again.

This pull requests adds "Reload platform" to the menu with an F5 hotkey. This will clear the platform then reload all the objects from the original files. The F5 hotkey is something I think people will be used to from the browser, but Ctrl+R would be another viable option.
