### PR TITLE
Support for .zip files in drag-and-drop and file menu

### DIFF
--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -9,6 +9,8 @@ import traceback
 import threading
 import math
 import platform
+import zipfile
+import tempfile
 
 import OpenGL
 OpenGL.ERROR_CHECKING = False
@@ -171,7 +173,15 @@ class SceneView(openglGui.glGuiPanel):
 			# pop first entry for processing and append new files at end
 			while filenames:
 				filename = filenames.pop(0)
-				if os.path.isdir(filename):
+				if filename.endswith('.zip'):
+					# Unpack zip, load all contained files.
+					destdir = tempfile.mkdtemp()
+					with zipfile.ZipFile(filename) as zipper:
+						zipper.extractall(destdir)
+					self.loadFiles([destdir])
+					# TODO: Cleanup (needs to be done safely)
+					continue
+				elif os.path.isdir(filename):
 					# directory: queue all included files and directories
 					filenames.extend(os.path.join(filename, f) for f in os.listdir(filename))
 				else:

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -211,7 +211,7 @@ class SceneView(openglGui.glGuiPanel):
 	def showLoadModel(self, button = 1):
 		if button == 1:
 			dlg=wx.FileDialog(self, _("Open 3D model"), os.path.split(profile.getPreference('lastFile'))[0], style=wx.FD_OPEN|wx.FD_FILE_MUST_EXIST|wx.FD_MULTIPLE)
-			dlg.SetWildcard(meshLoader.loadWildcardFilter() + imageToMesh.wildcardList() + "|GCode file (*.gcode)|*.g;*.gcode;*.G;*.GCODE")
+			dlg.SetWildcard(meshLoader.loadWildcardFilter() + imageToMesh.wildcardList() + "|GCode file (*.gcode)|*.g;*.gcode;*.G;*.GCODE|Zip file (*.zip)|*.zip")
 			if dlg.ShowModal() != wx.ID_OK:
 				dlg.Destroy()
 				return


### PR DESCRIPTION
When playing with Cura with Thingverse, it became tedious to download each individual .stl and load them separately.  The proposed patch would allow for the "Download All" link (which produces a .zip) to be imported directly via drag-and-drop into Cura.  In addition, .zip files on the user's drive could also be imported and all the .stl files automatically added.

This change is pretty alpha.  I tested it under Linux but I don't have the means for Windows, etc.  In addition, the base code could probably be extended to not decompress the zip itself (to avoid drive clutter) and/or clean up after the import is complete.

The advantage to not doing those things, however, is that the files listed in the recent files list would still be accessible as long as the temp files continued to exist (on Linux, the next reboot).  
