### PR TITLE
add .hgignore to make use of Mercurial easier

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,7 @@
+syntax: glob
+*.pyc
+*.deb
+CuraEngine
+Power
+scripts/linux/debian
+scripts/darwin/dist/Cura.app


### PR DESCRIPTION
for people using Mercurial instead of git this makes life easier
