### PR TITLE
Show current printing height in gcode view

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,7 @@
+syntax: glob
+*.pyc
+*.deb
+CuraEngine
+Power
+scripts/linux/debian
+scripts/darwin/dist/Cura.app

--- a/Cura/gui/printWindow.py
+++ b/Cura/gui/printWindow.py
@@ -93,6 +93,9 @@ class printProcessMonitor():
 def startPrintInterface(filename):
 	#startPrintInterface is called from the main script when we want the printer interface to run in a separate process.
 	# It needs to run in a separate process, as any running python code blocks the GCode sender python code (http://wiki.python.org/moin/GlobalInterpreterLock).
+
+	sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)
+
 	app = wx.App(False)
 	resources.setupLocalization(profile.getPreference('language'))
 	printWindowHandle = printWindow()

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -292,6 +292,7 @@ class SceneView(openglGui.glGuiPanel):
 		self._usbPrintMonitor.loadFile(self._gcodeFilename, self._slicer.getID())
 		if self._gcodeFilename == self._slicer.getGCodeFilename():
 			self._slicer.submitSliceInfoOnline()
+		self.viewSelection.setValue(4)
 
 	def showSaveGCode(self):
 		if len(self._scene._objectList) < 1:
@@ -1227,16 +1228,28 @@ void main(void)
 		self._drawMachine()
 
 		if self._usbPrintMonitor.getState() == 'PRINTING' and self._usbPrintMonitor.getID() == self._slicer.getID():
-			glEnable(GL_BLEND)
 			z = self._usbPrintMonitor.getZ()
-			size = self._machineSize
-			glColor4ub(255,255,0,128)
-			glBegin(GL_QUADS)
-			glVertex3f(-size[0]/2,-size[1]/2, z)
-			glVertex3f( size[0]/2,-size[1]/2, z)
-			glVertex3f( size[0]/2, size[1]/2, z)
-			glVertex3f(-size[0]/2, size[1]/2, z)
-			glEnd()
+			if self.viewMode == 'gcode':
+				layer_height = profile.getProfileSettingFloat('layer_height')
+				layer1_height = profile.getProfileSettingFloat('bottom_thickness')
+				if layer_height > 0:
+					if layer1_height > 0:
+						layer = int((z - layer1_height) / layer_height) + 1
+					else:
+						layer = int(z / layer_height)
+				else:
+					layer = 1
+				self.layerSelect.setValue(layer)
+			else:
+				size = self._machineSize
+				glEnable(GL_BLEND)
+				glColor4ub(255,255,0,128)
+				glBegin(GL_QUADS)
+				glVertex3f(-size[0]/2,-size[1]/2, z)
+				glVertex3f( size[0]/2,-size[1]/2, z)
+				glVertex3f( size[0]/2, size[1]/2, z)
+				glVertex3f(-size[0]/2, size[1]/2, z)
+				glEnd()
 
 		if self.viewMode == 'gcode':
 			if self._gcodeLoadThread is not None and self._gcodeLoadThread.isAlive():

--- a/Cura/gui/util/openglGui.py
+++ b/Cura/gui/util/openglGui.py
@@ -1030,7 +1030,7 @@ class glSlider(glGuiControl):
 		else:
 			valueNormalized = 0
 		glTranslate(0.0,scrollLength/2,0)
-		if self._focus:
+		if True:  # self._focus:
 			glColor4ub(0,0,0,255)
 			glPushMatrix()
 			glTranslate(-w/2,opengl.glGetStringSize(str(self._minValue))[1]/2,0)

--- a/Cura/util/version.py
+++ b/Cura/util/version.py
@@ -53,7 +53,8 @@ def getVersion(getGitVersion = True):
 
 def isDevVersion():
 	gitPath = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "../../.git"))
-	return os.path.exists(gitPath)
+	hgPath  = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__file__))[0], "../../.hg"))
+	return os.path.exists(gitPath) or os.path.exists(hgPath)
 
 def checkForNewerVersion():
 	if isDevVersion():


### PR DESCRIPTION
The current printing height is shown in gcode view by setting the top layer or the yellow plane in other views.
The slider now shows the numbers all the time to always show the current layer number (not sure if this is the best solution, but don't see another).
