### PR TITLE
fix chown on linux/debian

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -160,7 +160,7 @@ if [ "$BUILD_TARGET" = "debian" ]; then
 	cp scripts/linux/cura.py scripts/linux/debian/usr/share/cura/
 	cp -a Power/power scripts/linux/debian/usr/share/cura/
 	echo $BUILD_NAME > scripts/linux/debian/usr/share/cura/Cura/version
-	sudo chown root:root scripts/linux/debian -R
+	sudo chown root:root scripts/linux/debian/usr -R
 	sudo chmod 755 scripts/linux/debian/usr -R
 	sudo chmod 755 scripts/linux/debian/DEBIAN -R
 	cd scripts/linux


### PR DESCRIPTION
the package creation fails (for me) if scripts/linux/debian/DEBIAN is owned by root, so I restrict the chown to scripts/linux/debian/usr.
I created a similar patch before (which did a bit too much I think), this was reverted by some other patch, perhaps fixing it's problems.
I wonder how someone can create the package with having chown DEBIAN to root.
Perhaps do you compile as root (which I wouldn't recommend).
Hopefully this works for everyone on linux debian.
