### PR TITLE
Render circular bed when enabling bed at center

### DIFF
--- a/Cura/gui/preferencesDialog.py
+++ b/Cura/gui/preferencesDialog.py
@@ -83,6 +83,7 @@ class machineSettingsDialog(wx.Dialog):
 			configBase.SettingRow(left, 'extruder_amount', index=idx)
 			configBase.SettingRow(left, 'has_heated_bed', index=idx)
 			configBase.SettingRow(left, 'machine_center_is_zero', index=idx)
+			configBase.SettingRow(left, 'machine_shape', index=idx)
 			configBase.SettingRow(left, 'gcode_flavor', index=idx)
 
 			configBase.TitleRow(right, _("Printer head size"))

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -1427,12 +1427,17 @@ void main(void)
 
 		polys = profile.getMachineSizePolygons()
 		height = profile.getMachineSettingFloat('machine_height')
+		circular = profile.getMachineSetting('machine_shape') == 'Circular'
 		glBegin(GL_QUADS)
 		for n in xrange(0, len(polys[0])):
-			if n % 2 == 0:
-				glColor4ub(5, 171, 231, 96)
+			if not circular:
+				if n % 2 == 0:
+					glColor4ub(5, 171, 231, 96)
+				else:
+					glColor4ub(5, 171, 231, 64)
 			else:
-				glColor4ub(5, 171, 231, 64)
+				glColor4ub(5, 171, 231, 96)
+
 			glVertex3f(polys[0][n][0], polys[0][n][1], height)
 			glVertex3f(polys[0][n][0], polys[0][n][1], 0)
 			glVertex3f(polys[0][n-1][0], polys[0][n-1][1], 0)

--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -362,6 +362,7 @@ setting('machine_width', '205', float, 'machine', 'hidden').setLabel(_("Maximum 
 setting('machine_depth', '205', float, 'machine', 'hidden').setLabel(_("Maximum depth (mm)"), _("Size of the machine in mm"))
 setting('machine_height', '200', float, 'machine', 'hidden').setLabel(_("Maximum height (mm)"), _("Size of the machine in mm"))
 setting('machine_center_is_zero', 'False', bool, 'machine', 'hidden').setLabel(_("Machine center 0,0"), _("Machines firmware defines the center of the bed as 0,0 instead of the front left corner."))
+setting('machine_shape', 'Square', ['Square','Circular'], 'machine', 'hidden').setLabel(_("Build area shape"), _("The shape of machine build area."))
 setting('ultimaker_extruder_upgrade', 'False', bool, 'machine', 'hidden')
 setting('has_heated_bed', 'False', bool, 'machine', 'hidden').setLabel(_("Heated bed"), _("If you have an heated bed, this enabled heated bed settings (requires restart)"))
 setting('gcode_flavor', 'RepRap (Marlin/Sprinter)', ['RepRap (Marlin/Sprinter)', 'UltiGCode', 'MakerBot'], 'machine', 'hidden').setLabel(_("GCode Flavor"), _("Flavor of generated GCode.\nRepRap is normal 5D GCode which works on Marlin/Sprinter based firmwares.\nUltiGCode is a variation of the RepRap GCode which puts more settings in the machine instead of the slicer.\nMakerBot GCode has a few changes in the way GCode is generated, but still requires MakerWare to generate to X3G."))
@@ -880,14 +881,15 @@ def getMachineCenterCoords():
 def getMachineSizePolygons():
 	size = numpy.array([getMachineSettingFloat('machine_width'), getMachineSettingFloat('machine_depth'), getMachineSettingFloat('machine_height')], numpy.float32)
 	ret = []
-	ret.append(numpy.array([[-size[0]/2,-size[1]/2],[ size[0]/2,-size[1]/2],[ size[0]/2, size[1]/2], [-size[0]/2, size[1]/2]], numpy.float32))
-
-	# Circle platform for delta printers...
-	# circle = []
-	# steps = 16
-	# for n in xrange(0, steps):
-	# 	circle.append([math.cos(float(n)/steps*2*math.pi) * size[0]/2, math.sin(float(n)/steps*2*math.pi) * size[0]/2])
-	# ret.append(numpy.array(circle, numpy.float32))
+	if getMachineSetting('machine_shape') == 'Circular':
+		# Circle platform for delta printers...
+		circle = []
+		steps = 32
+		for n in xrange(0, steps):
+			circle.append([math.cos(float(n)/steps*2*math.pi) * size[0]/2, math.sin(float(n)/steps*2*math.pi) * size[1]/2])
+		ret.append(numpy.array(circle, numpy.float32))
+	else:
+		ret.append(numpy.array([[-size[0]/2,-size[1]/2],[size[0]/2,-size[1]/2],[size[0]/2, size[1]/2], [-size[0]/2, size[1]/2]], numpy.float32))
 
 	if getMachineSetting('machine_type') == 'ultimaker2':
 		#UM2 no-go zones


### PR DESCRIPTION
Enabled commented code for circular bed and tied it to "Machine center 0,0" setting.
Changed the commented code to use 32 sides rather than 16
Changed commented code to allow oval bed
Changed alternating color walls of build area to solid when using circular bed (it hurt the eyes)

I wasn't sure if this had been disabled because it just had not been implemented yet, or it wasn't wanted at all. I'm guessing this PR will give me the answer.
