### PR TITLE
Fix most communication problems (#698 without waiting for "start")

### DIFF
--- a/Cura/cura.py
+++ b/Cura/cura.py
@@ -28,7 +28,9 @@ def main():
 
 	(options, args) = parser.parse_args()
 
+	print "load preferences from " + profile.getPreferencePath()
 	profile.loadPreferences(profile.getPreferencePath())
+
 	if options.profile is not None:
 		profile.setProfileFromString(options.profile)
 	elif options.profileini is not None:

--- a/Cura/util/machineCom.py
+++ b/Cura/util/machineCom.py
@@ -231,9 +231,9 @@ class MachineCom(object):
 		return "?%d?" % (self._state)
 	
 	def getShortErrorString(self):
-		if len(self._errorValue) < 20:
+		if len(self._errorValue) < 30:
 			return self._errorValue
-		return self._errorValue[:20] + "..."
+		return self._errorValue[:30] + "..."
 
 	def getErrorString(self):
 		return self._errorValue

--- a/Cura/util/machineCom.py
+++ b/Cura/util/machineCom.py
@@ -440,22 +440,22 @@ class MachineCom(object):
 				if line == '':
 					if self._extruderCount > 0:
 						self._temperatureRequestExtruder = (self._temperatureRequestExtruder + 1) % self._extruderCount
-						self._sendCommand("M105 T%d" % (self._temperatureRequestExtruder))
+						self.sendCommand("M105 T%d" % (self._temperatureRequestExtruder))
 					else:
-						self._sendCommand("M105")
+						self.sendCommand("M105")
 					tempRequestTimeout = time.time() + 5
 			elif self._state == self.STATE_PRINTING:
-				if line == '' and time.time() > timeout:
-					self._log("Communication timeout during printing, forcing a line")
-					line = 'ok'
 				#Even when printing request the temperature every 5 seconds.
 				if time.time() > tempRequestTimeout:
 					if self._extruderCount > 0:
 						self._temperatureRequestExtruder = (self._temperatureRequestExtruder + 1) % self._extruderCount
-						self._sendCommand("M105 T%d" % (self._temperatureRequestExtruder))
+						self.sendCommand("M105 T%d" % (self._temperatureRequestExtruder))
 					else:
-						self._sendCommand("M105")
+						self.sendCommand("M105")
 					tempRequestTimeout = time.time() + 5
+				if line == '' and time.time() > timeout:
+					self._log("Communication timeout during printing, forcing a line")
+					line = 'ok'
 				if 'ok' in line:
 					timeout = time.time() + 5
 					if not self._commandQueue.empty():


### PR DESCRIPTION
see #698

I removed this patch as daid suggested:

elif 'ok' in line or 'start' in line:
           self._changeState(self.STATE_OPERATIONAL)

hope the request will be accepted now.

Changing the other pull request didn't work with Mercurial, so I created a new one
