### PR TITLE
fix issue #704, replacing variables in gcode file damaging line at file ...

### DIFF
--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -963,8 +963,8 @@ def replaceGCodeTags(filename, gcodeInt):
 def replaceGCodeTagsFromSlicer(filename, slicerInt):
 	f = open(filename, 'r+')
 	data = f.read(2048)
-	data = data.replace('#P_TIME#', slicerInt.getPrintTime())
-	data = data.replace('#F_AMNT#', slicerInt.getFilamentAmount())
+	data = data.replace('#P_TIME#', ('%8.2f' % (int(slicerInt._printTimeSeconds)))[-8:])
+	data = data.replace('#F_AMNT#', ('%8.2f' % (slicerInt._filamentMM[0]))[-8:])
 	data = data.replace('#F_WGHT#', ('%8.2f' % (float(slicerInt.getFilamentWeight()) * 1000))[-8:])
 	cost = slicerInt.getFilamentCost()
 	if cost is None:


### PR DESCRIPTION
see issue #704

I think the variables starting with underline should be kept private etc.
but this is a temporary workaround until the changes daid announced in issue #704
just to fix the bug for now...
