### PR TITLE
fix #713: debian_amd64/debian_i386 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ sudo apt-get install python-setuptools
 
 cd Cura
 
-sudo ./package.sh debian
+sudo ./package.sh debian_amd64          # or debian_i386 for 32bit
 
 sudo dpkg -i ./scripts/linux/Cura*.deb
 ```
@@ -51,31 +51,31 @@ We assume you already have Apple hardware with [64bit processor](http://support.
 ###Install Python
 You'll need **non-system**, **framework-based**, **universal** with **deployment target set to 10.6** build of Python 2.7
 
-**non-system**: Output of  
-`python -c "import sys; print sys.prefix"`  
+**non-system**: Output of
+`python -c "import sys; print sys.prefix"`
 should *not* start with *"/System/Library/Frameworks/Python.framework/"*.
 
-**framework-based**: Output of  
-`python -c "import distutils.sysconfig as c; print(c.get_config_var('PYTHONFRAMEWORK'))"`  
+**framework-based**: Output of
+`python -c "import distutils.sysconfig as c; print(c.get_config_var('PYTHONFRAMEWORK'))"`
 should be non-empty string. E.g. *Python*.
 
-**universal**: Output of  
-``lipo -info `which python` ``  
+**universal**: Output of
+``lipo -info `which python` ``
 should include both i386 and x86_64. E.g *"Architectures in the fat file: /usr/local/bin/python are: i386 x86_64"*.
 
-**deployment target set to 10.6**: Output of  
-``otool -l `which python` ``  
+**deployment target set to 10.6**: Output of
+``otool -l `which python` ``
 should contain *"cmd LC_VERSION_MIN_MACOSX ... version 10.6"*.
 
-The easiest way to install it is via [Homebrew](http://mxcl.github.com/homebrew/) using the formula from Cura's repo:  
-`brew install --build-bottle --fresh Cura/scripts/darwin/python.rb --universal`  
+The easiest way to install it is via [Homebrew](http://mxcl.github.com/homebrew/) using the formula from Cura's repo:
+`brew install --build-bottle --fresh Cura/scripts/darwin/python.rb --universal`
 Note if you already have Python installed via Homebrew, you have to uninstall it first.
 
 You can also install [official build](http://www.python.org/ftp/python/2.7.3/python-2.7.3-macosx10.6.dmg).
 
 
 ###Configure Virtualenv
-Create new virtualenv. If you have [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) installed:  
+Create new virtualenv. If you have [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/) installed:
 `mkvirtualenv Cura`
 
 wxPython cannot be installed via pip, we have to build it from source by specifing prefix to our virtualenv.
@@ -108,8 +108,8 @@ Assuming you have virtualenv at *~/.virtualenvs/Cura/* and [wxPython sources](ht
         --with-osx_cocoa \
         --with-zlib=builtin
 
-2. `make install`  
-    Note to speedup the process I recommend you to enable multicore build by adding the -j*cores* flag:  
+2. `make install`
+    Note to speedup the process I recommend you to enable multicore build by adding the -j*cores* flag:
     `make -j4 install`
 3. `cd` into *~/Downloads/wxPython-src-2.9.4.0/wxPython/*
 4. Build wxPython (Note `python` is the python of your virtualenv):
@@ -143,17 +143,17 @@ Assuming you have virtualenv at *~/.virtualenvs/Cura/* and [wxPython sources](ht
         export PYTHONHOME=$ENV
         exec $PYTHON "$@"
 
-At this point virtualenv is configured for wxPython development.  
+At this point virtualenv is configured for wxPython development.
 Remember to use `python` for pacakging and `pythonw` to run app for debugging.
 
 
 ###Install Python Packages
-Required python packages are specified in *requirements.txt* and *requirements_darwin.txt*  
+Required python packages are specified in *requirements.txt* and *requirements_darwin.txt*
 If you use virtualenv, installing requirements as easy as `pip install -r requirements_darwin.txt`
 
 
 ###Package Cura into application
-Ensure that virtualenv is activated, so `python` points to the python of your virtualenv (e.g. ~/.virtualenvs/Cura/bin/python).Use package.sh to build Cura:  
+Ensure that virtualenv is activated, so `python` points to the python of your virtualenv (e.g. ~/.virtualenvs/Cura/bin/python).Use package.sh to build Cura:
 `./package.sh darwin`
 
 Note that application is only guaranteed to work on Mac OS X version used to build and higher, but may not support lower versions.


### PR DESCRIPTION
fixes README for split of target debian to debian_amd64/debian_i386.

(sorry, my editor also removed some trailing whitespace in other lines, which looks correct to me)
