### PR TITLE
Fix icon path in cura.desktop.

### DIFF
--- a/scripts/linux/debian_amd64/usr/share/applications/cura.desktop
+++ b/scripts/linux/debian_amd64/usr/share/applications/cura.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Cura
 Comment=Cura
-Icon=/usr/share/cura/Cura/resources/images/c.png
+Icon=/usr/share/cura/resources/images/c.png
 Exec=/usr/bin/python /usr/share/cura/cura.py
 Path=/usr/share/cura/
 StartupNotify=true

--- a/scripts/linux/debian_i386/usr/share/applications/cura.desktop
+++ b/scripts/linux/debian_i386/usr/share/applications/cura.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=Cura
 Comment=Cura
-Icon=/usr/share/cura/Cura/resources/images/c.png
+Icon=/usr/share/cura/resources/images/c.png
 Exec=/usr/bin/python /usr/share/cura/cura.py
 Path=/usr/share/cura/
 StartupNotify=true


### PR DESCRIPTION
Hardly worth the pull request, but here it is anyway. Building on Ubuntu did not give an icon for the launcher due to the movement of the resources folder.
