### PR TITLE
Package builder for FreeBSD is now ready! :-)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before posting issues (either Bugs, Feature requests or Requests for information
 Packaging
 ---------
 
-Cura development comes with a script "package.sh", this script has been designed to run under *nix OSes (Linux, MacOS). For Windows the package.sh script can be run from bash using git.
+Cura development comes with a script "package.sh", this script has been designed to run under *nix OSes (Linux, MacOS, FreeBSD). For Windows the package.sh script can be run from bash using git.
 The "package.sh" script generates a final release package. You should not need it during development, unless you are changing the release process. If you want to distribute your own version of Cura, then the package.sh script will allow you to do that.
 
 Both MacOS and Linux require some extra instructions for development, as you need to prepare an environment. Look below at the proper section to see what is needed.
@@ -78,6 +78,13 @@ The easiest way to install it is via [Homebrew](http://mxcl.github.com/homebrew/
 Note if you already have Python installed via Homebrew, you have to uninstall it first.
 
 You can also install [official build](http://www.python.org/ftp/python/2.7.3/python-2.7.3-macosx10.6.dmg).
+
+
+FreeBSD
+--------
+On FreeBSD simply use the Port Tree (`cd /usr/ports/cad/cura`) to create (`make package`) and install (`make install`) the package as root. Port will check for all necessary dependencies. You can also use the provided binary package with `pkg install Cura`.
+
+If you want to create an archive for local use the `package.sh freebsd` script (as an ordinary user) will give you a tarball with the program.
 
 
 ###Configure Virtualenv

--- a/package.sh
+++ b/package.sh
@@ -149,6 +149,50 @@ if [ "$BUILD_TARGET" = "darwin" ]; then
 fi
 
 #############################
+# FreeBSD by cederom@tlen.pl
+#############################
+
+if [ "$BUILD_TARGET" = "freebsd" ]; then
+	export CXX="c++"
+	rm -rf Power
+	if [ ! -d "Power" ]; then
+		git clone https://github.com/GreatFruitOmsk/Power
+	else
+		cd Power
+		git pull
+		cd ..
+	fi
+	rm -rf CuraEngine
+	git clone ${CURA_ENGINE_REPO}
+    if [ $? != 0 ]; then echo "Failed to clone CuraEngine"; exit 1; fi
+	gmake -j4 -C CuraEngine VERSION=${BUILD_NAME}
+    if [ $? != 0 ]; then echo "Failed to build CuraEngine"; exit 1; fi
+	rm -rf scripts/freebsd/dist
+	mkdir -p scripts/freebsd/dist/usr/local/share/cura
+	mkdir -p scripts/freebsd/dist/usr/local/share/applications
+	mkdir -p scripts/freebsd/dist/usr/local/bin
+	cp -a Cura scripts/freebsd/dist/usr/local/share/cura/
+	cp -a resources scripts/freebsd/dist/usr/local/share/cura/
+	cp -a plugins scripts/freebsd/dist/usr/local/share/cura/
+	cp -a CuraEngine/build/CuraEngine scripts/freebsd/dist/usr/local/share/cura/
+	cp scripts/freebsd/cura.py scripts/freebsd/dist/usr/local/share/cura/
+	cp scripts/freebsd/cura.desktop scripts/freebsd/dist/usr/local/share/applications/
+	cp scripts/freebsd/cura scripts/freebsd/dist/usr/local/bin/
+	cp -a Power/power scripts/freebsd/dist/usr/local/share/cura/
+	echo $BUILD_NAME > scripts/freebsd/dist/usr/local/share/cura/Cura/version
+	# Create archive or package if root
+	if [ `whoami` == "root" ]; then
+	    echo "Building a package for FreeBSD not yet implemented! Use the port Luke!"
+	else
+	    echo "You are not root, building simple package archive..."
+	    cd scripts/freebsd/dist
+	    pwd
+	    $TAR czf ../../../${TARGET_DIR}.tar.gz *
+	fi
+	exit
+fi
+
+#############################
 # Debian 32bit .deb
 #############################
 
@@ -219,7 +263,6 @@ if [ "$BUILD_TARGET" = "debian_amd64" ]; then
 	sudo chown `id -un`:`id -gn` ${BUILD_TARGET} -R
 	exit
 fi
-
 
 #############################
 # Rest

--- a/package.sh
+++ b/package.sh
@@ -149,7 +149,7 @@ if [ "$BUILD_TARGET" = "darwin" ]; then
 fi
 
 #############################
-# FreeBSD by cederom@tlen.pl
+# FreeBSD part by CeDeROM
 #############################
 
 if [ "$BUILD_TARGET" = "freebsd" ]; then
@@ -168,26 +168,36 @@ if [ "$BUILD_TARGET" = "freebsd" ]; then
 	gmake -j4 -C CuraEngine VERSION=${BUILD_NAME}
     if [ $? != 0 ]; then echo "Failed to build CuraEngine"; exit 1; fi
 	rm -rf scripts/freebsd/dist
-	mkdir -p scripts/freebsd/dist/usr/local/share/cura
-	mkdir -p scripts/freebsd/dist/usr/local/share/applications
-	mkdir -p scripts/freebsd/dist/usr/local/bin
-	cp -a Cura scripts/freebsd/dist/usr/local/share/cura/
-	cp -a resources scripts/freebsd/dist/usr/local/share/cura/
-	cp -a plugins scripts/freebsd/dist/usr/local/share/cura/
-	cp -a CuraEngine/build/CuraEngine scripts/freebsd/dist/usr/local/share/cura/
-	cp scripts/freebsd/cura.py scripts/freebsd/dist/usr/local/share/cura/
-	cp scripts/freebsd/cura.desktop scripts/freebsd/dist/usr/local/share/applications/
-	cp scripts/freebsd/cura scripts/freebsd/dist/usr/local/bin/
-	cp -a Power/power scripts/freebsd/dist/usr/local/share/cura/
-	echo $BUILD_NAME > scripts/freebsd/dist/usr/local/share/cura/Cura/version
+	mkdir -p scripts/freebsd/dist/share/cura
+	mkdir -p scripts/freebsd/dist/share/applications
+	mkdir -p scripts/freebsd/dist/bin
+	cp -a Cura scripts/freebsd/dist/share/cura/
+	cp -a resources scripts/freebsd/dist/share/cura/
+	cp -a plugins scripts/freebsd/dist/share/cura/
+	cp -a CuraEngine/build/CuraEngine scripts/freebsd/dist/share/cura/
+	cp scripts/freebsd/cura.py scripts/freebsd/dist/share/cura/
+	cp scripts/freebsd/cura.desktop scripts/freebsd/dist/share/applications/
+	cp scripts/freebsd/cura scripts/freebsd/dist/bin/
+	cp -a Power/power scripts/freebsd/dist/share/cura/
+	echo $BUILD_NAME > scripts/freebsd/dist/share/cura/Cura/version
+	#Create file list (pkg-plist)
+	cd scripts/freebsd/dist
+	find * -type f > ../pkg-plist
+	DIRLVL=20; while [ $DIRLVL -ge 0 ]; do
+		DIRS=`find share/cura -type d -depth $DIRLVL`
+		for DIR in $DIRS; do
+			echo "@dirrm $DIR" >> ../pkg-plist
+		done
+		DIRLVL=`expr $DIRLVL - 1`
+	done
+	cd ..
 	# Create archive or package if root
 	if [ `whoami` == "root" ]; then
-	    echo "Building a package for FreeBSD not yet implemented! Use the port Luke!"
+	    echo "Are you root? Use the Port Luke! :-)"
 	else
 	    echo "You are not root, building simple package archive..."
-	    cd scripts/freebsd/dist
 	    pwd
-	    $TAR czf ../../../${TARGET_DIR}.tar.gz *
+	    $TAR czf ../../${TARGET_DIR}.tar.gz dist/**
 	fi
 	exit
 fi

--- a/scripts/freebsd/cura
+++ b/scripts/freebsd/cura
@@ -1,0 +1,2 @@
+#!/bin/sh
+PYTHONPATH=$PYTHONPATH:/usr/local/share/cura/ `echo /usr/bin/env python` /usr/local/share/cura/cura.py "$@"

--- a/scripts/freebsd/cura.desktop
+++ b/scripts/freebsd/cura.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Cura
+Comment=Cura is a complete and open slicing solution for RepRap 3D printers
+Icon=/usr/local/share/cura/resources/images/c.png
+Exec=/usr/local/bin/cura
+Path=/usr/local/share/cura/
+StartupNotify=true
+Terminal=false
+Categories=GNOME;GTK;Utility;

--- a/scripts/freebsd/cura.py
+++ b/scripts/freebsd/cura.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import os, sys
+
+sys.path.insert(1, os.path.dirname(__file__))
+
+try:
+	import numpy
+	import OpenGL
+	import wx
+	import serial
+	import power
+except ImportError as e:
+	if e.message[0:16] == 'No module named ':
+		module = e.message[16:]
+
+		if module == 'OpenGL':
+			module = 'PyOpenGL'
+		elif module == 'serial':
+			module = 'pyserial'
+		print 'Requires ' + module
+
+		if module == 'power':
+			print "Install from: https://github.com/GreatFruitOmsk/Power"
+		else:
+			print "Try sudo easy_install " + module
+		print e.message
+    
+	exit(1)
+
+
+import Cura.cura as cura
+
+cura.main()


### PR DESCRIPTION
Package builder is now ready and compatible with FreeBSD Ports Build Infrastructure. When commits are merged please make a release and I will officially add Cura into FreeBSD Port Tree so anyone can use this beautiful tool on this marvelous OS :-)

Please note that Port Build is accomplished by the FreeBSD project and provided as binary packages with pkgng, or user can build them by hand using /usr/ports stuff, so no packages needs to be provided on the project website as they are provided by the system, only an information that FreeBSD is supported :-)
