### PR TITLE
util: Remove uneccesary and unwanted import of wx

### DIFF
--- a/Cura/util/resources.py
+++ b/Cura/util/resources.py
@@ -8,8 +8,6 @@ import os
 import sys
 import glob
 
-#Cura/util classes should not depend on wx...
-import wx
 import gettext
 
 if sys.platform.startswith('darwin'):


### PR DESCRIPTION
This dependency was actually removed in e17446726f7fbac31f97a0e51536571822987215
Caused problems for non-GUI uses of this modules, like in CuraServer
