### PR TITLE
Make package.sh work for paths containing spaces

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -82,7 +82,7 @@ fi
 # Change working directory to the directory the script is in
 # http://stackoverflow.com/a/246128
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR
+cd "$SCRIPT_DIR"
 
 checkTool git "git: http://git-scm.com/"
 checkTool curl "curl: http://curl.haxx.se/"


### PR DESCRIPTION
Previously, package.sh would truncate the current directory at the first space, and install everything in that folder.  It now respects the full path.
