### PR TITLE
avoid TypeError when reading the active io

### DIFF
--- a/Cura/util/bigDataStorage.py
+++ b/Cura/util/bigDataStorage.py
@@ -21,14 +21,17 @@ class BigDataStorage(object):
 		self._active.seek(0)
 		self._read_index = 0
 
+	def activeRead(self, size=None):
+		return self._active.read(size) if size != None else self._active.read()
+
 	def read(self, size=None):
-		ret = self._active.read(size)
+		ret = self.activeRead(size)
 		if ret == '':
 			if self._read_index + 1 < len(self._list):
 				self._read_index += 1
 				self._active = self._list[self._read_index]
 				self._active.seek(0)
-				ret = self._active.read(size)
+				ret = self.activeRead(size)
 		return ret
 
 	def replaceAtStart(self, key, value):


### PR DESCRIPTION
I ran into the following error while trying to slice with the current code on a raspberry pi running Debian:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/brad/projects/Cura/Cura/cura.py", line 89, in <module>
    main()
  File "/home/brad/projects/Cura/Cura/cura.py", line 77, in main
    data = gcode.read()
  File "Cura/util/bigDataStorage.py", line 25, in read
    ret = self._active.read(size)
TypeError: an integer is required
```

This PR is my proposed solution to fix the problem.
