### PR TITLE
Prevent unresponsive print window

### DIFF
--- a/Cura/gui/printWindow.py
+++ b/Cura/gui/printWindow.py
@@ -444,6 +444,9 @@ class printWindowBasic(wx.Frame):
 		info += '\n\n'
 		self.statsText.SetLabel(info)
 
+	def _addTermLog(self, msg):
+		pass
+
 	def _updateButtonStates(self):
 		self.connectButton.Show(self._printerConnection.hasActiveConnection())
 		self.connectButton.Enable(not self._printerConnection.isActiveConnectionOpen() and not self._printerConnection.isActiveConnectionOpening())


### PR DESCRIPTION
If the default print window is used, and the printer sends a message
back to the main process, the receiving thread calls _addTermLog, which
was undefined on the printWindowBasic.  It has now been defined.
