### PR TITLE
SD Card Folder Structure replication.

### DIFF
--- a/Cura/gui/preferencesDialog.py
+++ b/Cura/gui/preferencesDialog.py
@@ -45,10 +45,11 @@ class preferencesDialog(wx.Dialog):
 		#configBase.TitleRow(right, 'Slicer settings')
 		#configBase.SettingRow(right, 'save_profile')
 
-		#configBase.TitleRow(right, 'SD Card settings')
-
-		configBase.TitleRow(right, _("Cura settings"))
+		configBase.TitleRow(right, 'SD Card settings')
 		configBase.SettingRow(right, 'auto_detect_sd')
+		configBase.SettingRow(right, 'sdcard_rootfolder')
+		
+		configBase.TitleRow(right, _("Cura settings"))
 		configBase.SettingRow(right, 'check_for_updates')
 		configBase.SettingRow(right, 'submit_slice_information')
 

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -253,6 +253,19 @@ class SceneView(openglGui.glGuiPanel):
 				else:
 					drive = drives[0]
 				filename = self._scene._objectList[0].getName() + profile.getGCodeExtension()
+				
+				#check if the file is part of the root folder. If so, create folders on sd card to get the same folder hierarchy.
+				repDir = profile.getPreference("sdcard_rootfolder")
+				if os.path.exists(repDir) and os.path.isdir(repDir):
+				        repDir = os.path.abspath(repDir)
+				        originFilename = os.path.abspath( self._scene._objectList[0].getOriginFilename() )
+				        if os.path.dirname(originFilename).startswith(repDir):
+				                filename = os.path.splitext(originFilename[len(repDir):])[0] + profile.getGCodeExtension()
+				                sdPath = os.path.dirname(os.path.join( drive[1], filename))
+				                if not os.path.exists(sdPath):
+				                        print "Creating replication directory:", sdPath
+				                        os.makedirs(sdPath)
+
 				threading.Thread(target=self._saveGCode,args=(drive[1] + filename, drive[1])).start()
 			elif connectionGroup is not None:
 				connections = connectionGroup.getAvailableConnections()

--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -485,6 +485,7 @@ setting('save_profile', 'False', bool, 'preference', 'hidden').setLabel(_("Save 
 setting('filament_cost_kg', '0', float, 'preference', 'hidden').setLabel(_("Cost (price/kg)"), _("Cost of your filament per kg, to estimate the cost of the final print."))
 setting('filament_cost_meter', '0', float, 'preference', 'hidden').setLabel(_("Cost (price/m)"), _("Cost of your filament per meter, to estimate the cost of the final print."))
 setting('auto_detect_sd', 'True', bool, 'preference', 'hidden').setLabel(_("Auto detect SD card drive"), _("Auto detect the SD card. You can disable this because on some systems external hard-drives or USB sticks are detected as SD card."))
+setting('sdcard_rootfolder', '', str, 'preference', 'hidden').setLabel(_("Base folder to replicate on SD card"), _("The specified folder will be used as a base path. Any gcode generated from object coming from within that folder will be automatically saved on the SD card at the same sub-folder. Any object coming from outside of this path will save the gcode on the root folder of the card."))
 setting('check_for_updates', 'True', bool, 'preference', 'hidden').setLabel(_("Check for updates"), _("Check for newer versions of Cura on startup"))
 setting('submit_slice_information', 'False', bool, 'preference', 'hidden').setLabel(_("Send usage statistics"), _("Submit anonymous usage information to improve future versions of Cura"))
 setting('youmagine_token', '', str, 'preference', 'hidden')


### PR DESCRIPTION
In the preference settings there is now a sd card section regrouping the sd card auto detect option and the new base folder to replicate.
If the path is defined it will copy an gcode from stl located under that folder and place it at the same location on the sd card.

First pull request with only the needed change.
