### PR TITLE
Cut off (object_sink setting) support tall objects

### DIFF
--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -51,6 +51,7 @@ class SceneView(openglGui.glGuiPanel):
 		self._viewTarget = numpy.array([0,0,0], numpy.float32)
 		self._animView = None
 		self._animZoom = None
+		self._lastObjectSink = None
 		self._platformMesh = {}
 		self._platformTexture = None
 		self._isSimpleMode = True
@@ -543,6 +544,12 @@ class SceneView(openglGui.glGuiPanel):
 		self.sceneUpdated()
 
 	def sceneUpdated(self):
+
+		objectSink = profile.getProfileSettingFloat("object_sink")
+		if self._lastObjectSink != objectSink:
+			self._lastObjectSink = objectSink
+			self._scene.updateHeadSize()
+
 		wx.CallAfter(self._sceneUpdateTimer.Start, 500, True)
 		self._engine.abortEngine()
 		self._scene.updateSizeOffsets()

--- a/Cura/util/objectScene.py
+++ b/Cura/util/objectScene.py
@@ -154,6 +154,7 @@ class Scene(object):
 		yMin = profile.getMachineSettingFloat('extruder_head_size_min_y')
 		yMax = profile.getMachineSettingFloat('extruder_head_size_max_y')
 		gantryHeight = profile.getMachineSettingFloat('extruder_head_size_height')
+		objectSink = profile.getProfileSettingFloat("object_sink")
 
 		self._leftToRight = xMin < xMax
 		self._frontToBack = yMin < yMax
@@ -162,7 +163,7 @@ class Scene(object):
 		self._gantryHeight = gantryHeight
 		self._oneAtATime = self._gantryHeight > 0 and profile.getPreference('oneAtATime') == 'True'
 		for obj in self._objectList:
-			if obj.getSize()[2] > self._gantryHeight:
+			if obj.getSize()[2] - objectSink > self._gantryHeight:
 				self._oneAtATime = False
 
 		headArea = numpy.array([[-xMin,-yMin],[ xMax,-yMin],[ xMax, yMax],[-xMin, yMax]], numpy.float32)
@@ -267,8 +268,10 @@ class Scene(object):
 			return polygon.polygonCollision(a._boundaryHull + a.getPosition(), b._boundaryHull + b.getPosition())
 
 	def checkPlatform(self, obj):
+		objectSink = profile.getProfileSettingFloat("object_sink")
+
 		area = obj._printAreaHull + obj.getPosition()
-		if obj.getSize()[2] > self._machineSize[2]:
+		if obj.getSize()[2] - objectSink > self._machineSize[2]:
 			return False
 		if not polygon.fullInside(area, self._machinePolygons[0]):
 			return False


### PR DESCRIPTION
Changes made to the Cut off value now trigger tests to check if Print one at a time mode can be reactivated.
Cut off is also used in z test to enable object within machine max height.

_I noticed that the slicer doesn't slice in print one at a time mode even if Cura enables it._

If you have any better idea on how to take it into account it would be good to look into it. Initially I wanted to allow to set a callback on profile settings but couldn't find a way that would not feel like a hack. I decided to test if cut off changed since the last sceneUpdated() to update the test for print one at a time mode.
