### PR TITLE
Fix G90/G91 interpretation regarding relative e

### DIFF
--- a/Cura/util/gcodeInterpreter.py
+++ b/Cura/util/gcodeInterpreter.py
@@ -151,7 +151,7 @@ class gcode(object):
 							pos[2] += z * scale
 					moveType = 'move'
 					if e is not None:
-						if absoluteE:
+						if absoluteE and posAbs:
 							e -= currentE
 						if e > 0.0:
 							moveType = 'extrude'


### PR DESCRIPTION
The documentation on the RepRap wiki is a bit unclear here, but Marlin decides whether e is relative with the expression

`axis_relative_modes[3] || relative_mode`<sup>1</sup>

where `axis_relative_modes[3] == not absoluteE` and `relative_mode == not posAbs` from Cura's GCodeInterpreter.

Therefore the expression to determine if e is absolute is:

```
    not {e is relative}
==> not (axis_relative_modes[3] || relative_mode)
==> not axis_relative_modes[3] and not relative_mode
==> absoluteE and posAbs
```

<sup>1</sup>This expression can be found in Ultimaker 2 Marlin [here](https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/Marlin_main.cpp#L2464).
