### PR TITLE
Adding new notifications for the user:

### DIFF
--- a/Cura/gui/mainWindow.py
+++ b/Cura/gui/mainWindow.py
@@ -285,6 +285,13 @@ class mainWindow(wx.Frame):
 		if Publisher is not None:
 			Publisher().subscribe(self.onPluginUpdate, "pluginupdate")
 
+		pluginCount = self.normalSettingsPanel.pluginPanel.GetActivePluginCount()
+		if pluginCount == 1:
+			self.scene.notification.message("Warning: 1 plugin from the previous session is still active.")
+
+		if pluginCount > 1:
+			self.scene.notification.message("Warning: %i plugins from the previous session are still active." % pluginCount)
+
 	def onPluginUpdate(self,msg): #receives commands from the plugin thread
 		cmd = str(msg.data).split(";")
 		if cmd[0] == "OpenPluginProgressWindow":

--- a/Cura/gui/pluginPanel.py
+++ b/Cura/gui/pluginPanel.py
@@ -202,3 +202,14 @@ class pluginPanel(wx.Panel):
 		if not os.path.exists(pluginInfo.getPluginBasePaths()[0]):
 			os.mkdir(pluginInfo.getPluginBasePaths()[0])
 		explorer.openExplorerPath(pluginInfo.getPluginBasePaths()[0])
+
+	def GetActivePluginCount(self):
+		pluginCount = 0
+		for pluginConfig in self.pluginConfig:
+			self._buildPluginPanel(pluginConfig)
+
+			for pluginTest in self.pluginList:
+				if pluginTest.getFilename() == pluginConfig['filename']:
+					pluginCount += 1
+
+		return pluginCount

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -39,7 +39,7 @@ class SceneView(openglGui.glGuiPanel):
 		self._yaw = 30
 		self._pitch = 60
 		self._zoom = 300
-		self._scene = objectScene.Scene()
+		self._scene = objectScene.Scene(self)
 		self._objectShader = None
 		self._objectLoadShader = None
 		self._focusObj = None
@@ -120,6 +120,8 @@ class SceneView(openglGui.glGuiPanel):
 		self.OnToolSelect(0)
 		self.updateToolButtons()
 		self.updateProfileToControls()
+
+
 
 	def loadGCodeFile(self, filename):
 		self.OnDeleteAll(None)

--- a/Cura/util/objectScene.py
+++ b/Cura/util/objectScene.py
@@ -108,7 +108,7 @@ class Scene(object):
 	The scene class keep track of an collection of objects on a build platform and their state.
 	It can figure out in which order to print them (if any) and if an object can be printed at all.
 	"""
-	def __init__(self):
+	def __init__(self, sceneView=None):
 		self._objectList = []
 		self._sizeOffsets = numpy.array([0.0,0.0], numpy.float32)
 		self._machineSize = numpy.array([100,100,100], numpy.float32)
@@ -121,6 +121,10 @@ class Scene(object):
 		self._frontToBack = True
 		self._gantryHeight = 60
 		self._oneAtATime = True
+
+		self._lastOneAtATime = False
+		self._lastResultOneAtATime = True
+		self._sceneView = sceneView
 
 	# update the physical machine dimensions
 	def updateMachineDimensions(self):
@@ -161,10 +165,28 @@ class Scene(object):
 		self._headSizeOffsets[0] = min(xMin, xMax)
 		self._headSizeOffsets[1] = min(yMin, yMax)
 		self._gantryHeight = gantryHeight
-		self._oneAtATime = self._gantryHeight > 0 and profile.getPreference('oneAtATime') == 'True'
-		for obj in self._objectList:
-			if obj.getSize()[2] - objectSink > self._gantryHeight:
-				self._oneAtATime = False
+
+		printOneAtATime = profile.getPreference('oneAtATime') == 'True'
+		self._oneAtATime = self._gantryHeight > 0 and printOneAtATime
+		if self._oneAtATime:
+			if not self._lastOneAtATime:
+				#print mode was changed by user. We need to reset that value to test with current scene content
+				self._lastResultOneAtATime = True
+
+			for obj in self._objectList:
+				if obj.getSize()[2] - objectSink > self._gantryHeight:
+					self._oneAtATime = False
+					if self._lastResultOneAtATime:
+						if self._sceneView:
+							self._sceneView.notification.message("Info: Print one at a time mode disabled. Object too tall.")
+						break
+
+		if self._lastOneAtATime and self._oneAtATime and not self._lastResultOneAtATime:
+			if self._sceneView:
+				self._sceneView.notification.message("Info: Print one at a time mode re-enabled.")
+
+		self._lastResultOneAtATime = self._oneAtATime
+		self._lastOneAtATime = printOneAtATime
 
 		headArea = numpy.array([[-xMin,-yMin],[ xMax,-yMin],[ xMax, yMax],[-xMin, yMax]], numpy.float32)
 


### PR DESCRIPTION
Hi Daid,

I'm proposing to add 3 new notification messages for the users. Based on the issues I have seen on the forum users seems to not take those into account. A simple notification could help them spot the issue.

Let me know if you think its inappropriate or if you think of any other one I could add.

Adding new notifications for the user:
- print one at a time mode notification if it get disabled due to object too tall
- print one at a time mode re activated after removing object too tall. (do not occur when the mode was not previously disabled)
- Checking active plugins on launch to warn user of plugins still active when starting a new session.
