### PR TITLE
Add printer connection plugin framework

### DIFF
--- a/Cura/util/pluginInfo.py
+++ b/Cura/util/pluginInfo.py
@@ -11,6 +11,7 @@ import platform
 import re
 import tempfile
 import cPickle as pickle
+import importlib
 
 from Cura.util import profile
 from Cura.util import resources
@@ -168,3 +169,10 @@ def runPostProcessingPlugins(engineResult):
 		f.close()
 		os.unlink(tempfilename)
 	return None
+
+def createPluginInstance(pluginInfo, *args):
+	fullFilename = pluginInfo.getFullFilename()
+	modulename = fullFilename[fullFilename.rfind("{0}plugins{0}".format(os.sep))+1:-3].replace(os.sep, '.')
+	createPluginInstanceMethod = getattr(importlib.import_module(modulename), "createPluginInstance")
+	return createPluginInstanceMethod(*args)
+

--- a/Cura/util/printerConnection/printerConnectionManager.py
+++ b/Cura/util/printerConnection/printerConnectionManager.py
@@ -8,6 +8,7 @@ As well as listing all printers under the right mouse button.
 __copyright__ = "Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License"
 
 import os
+import sys
 
 from Cura.util import profile
 from Cura.util import version
@@ -29,7 +30,10 @@ class PrinterConnectionManager(object):
 		self._groupList.append(doodle3dConnect.doodle3dConnectionGroup())
 
 		for p in pluginInfo.getPluginList('printerconnection'):
-			self._groupList.append(pluginInfo.createPluginInstance(p))
+			try:
+				self._groupList.append(pluginInfo.createPluginInstance(p))
+			except:
+				print "Error instantiating PrinterConnection plugin ({}): {}".format(p.getName(), sys.exc_info()[0])
 
 		#Sort the connections by highest priority first.
 		self._groupList.sort(reverse=True)

--- a/Cura/util/printerConnection/printerConnectionManager.py
+++ b/Cura/util/printerConnection/printerConnectionManager.py
@@ -7,8 +7,11 @@ As well as listing all printers under the right mouse button.
 """
 __copyright__ = "Copyright (C) 2013 David Braam - Released under terms of the AGPLv3 License"
 
+import os
+
 from Cura.util import profile
 from Cura.util import version
+from Cura.util import pluginInfo
 from Cura.util.printerConnection import dummyConnection
 from Cura.util.printerConnection import serialConnection
 from Cura.util.printerConnection import doodle3dConnect
@@ -24,6 +27,9 @@ class PrinterConnectionManager(object):
 			self._groupList.append(dummyConnection.dummyConnectionGroup())
 		self._groupList.append(serialConnection.serialConnectionGroup())
 		self._groupList.append(doodle3dConnect.doodle3dConnectionGroup())
+
+		for p in pluginInfo.getPluginList('printerconnection'):
+			self._groupList.append(pluginInfo.createPluginInstance(p))
 
 		#Sort the connections by highest priority first.
 		self._groupList.sort(reverse=True)


### PR DESCRIPTION
The intent of this change is to enable the addition of Printer Connection plugins to Cura, without the need for shipping the plugin along with Cura.

This is done by adding the ability to instantiate a plugin as an object, rather than simply executing python code. This is done by the addition of **init**.py in the plugins directory, and a new method in PluginInfo that will instantiate the plugin Object by calling createPluginInstance with an arbitrary number of arguments, given a PluginInfo instance.

If the plugin is in a directory, there must be an **init**.py file in the directory, and a script.py file that contains the createPluginInstance method.

If the plugin is contained in a single file, then it can be named arbitrarily, but must be placed in the plugins directory, and contain the createPluginInstance method.

The second piece is adding the usage of this new PluginInfo framework in the Printer Connection Manager code to add plugins that are "printerconnection" type, and subclass off of the PrinterConnectionBase.

For reference, I am trying to enable an OctoPrint Printer Connection to allow printing directly from Cura to OctoPrint.
