### PR TITLE
Added a way for the filename to be passed to the printer connection

### DIFF
--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -330,7 +330,7 @@ class SceneView(openglGui.glGuiPanel):
 				connection.window = printWindow.printWindowBasic(self, connection)
 		connection.window.Show()
 		connection.window.Raise()
-		if not connection.loadGCodeData(self._engine.getResult().getGCode()):
+		if not connection.loadGCodeData(self._engine.getResult().getGCode(), self._scene._objectList[0].getName() + profile.getGCodeExtension()):
 			if connection.isPrinting():
 				self.notification.message("Cannot start print, because other print still running.")
 			else:

--- a/Cura/gui/sceneView.py
+++ b/Cura/gui/sceneView.py
@@ -330,7 +330,7 @@ class SceneView(openglGui.glGuiPanel):
 				connection.window = printWindow.printWindowBasic(self, connection)
 		connection.window.Show()
 		connection.window.Raise()
-		if not connection.loadGCodeData(self._engine.getResult().getGCode(), self._scene._objectList[0].getName() + profile.getGCodeExtension()):
+		if not connection.loadGCodeDataForFilename(self._engine.getResult().getGCode(), self._scene._objectList[0].getName() + profile.getGCodeExtension()):
 			if connection.isPrinting():
 				self.notification.message("Cannot start print, because other print still running.")
 			else:

--- a/Cura/util/printerConnection/printerConnectionBase.py
+++ b/Cura/util/printerConnection/printerConnectionBase.py
@@ -51,6 +51,10 @@ class printerConnectionBase(object):
 		return self._name
 
 	#Load the data into memory for printing, returns True on success
+	def loadGCodeData(self, dataStream, filename):
+		return self.loadGCodeData(dataStream)
+
+	#Load the data into memory for printing, returns True on success
 	def loadGCodeData(self, dataStream):
 		return False
 

--- a/Cura/util/printerConnection/printerConnectionBase.py
+++ b/Cura/util/printerConnection/printerConnectionBase.py
@@ -50,7 +50,13 @@ class printerConnectionBase(object):
 	def getName(self):
 		return self._name
 
-	#Load the data into memory for printing, returns True on success
+	#The next two methods are similar in that they load the
+	#data into memory for printing, and return True on success.
+	#
+	#Only one of the methods should be overriden in the concrete
+	#class - the first if a filename for the gcode is desireable,
+	#the second if no filename is needed. The filename will be
+	#generated from the first file that is loaded onto the platter.
 	def loadGCodeDataForFilename(self, dataStream, filename):
 		return self.loadGCodeData(dataStream)
 

--- a/Cura/util/printerConnection/printerConnectionBase.py
+++ b/Cura/util/printerConnection/printerConnectionBase.py
@@ -51,7 +51,7 @@ class printerConnectionBase(object):
 		return self._name
 
 	#Load the data into memory for printing, returns True on success
-	def loadGCodeData(self, dataStream, filename):
+	def loadGCodeDataForFilename(self, dataStream, filename):
 		return self.loadGCodeData(dataStream)
 
 	#Load the data into memory for printing, returns True on success


### PR DESCRIPTION
This allows the passing of the guessed filename (same value as is suggested for the gcode filename) to be passed to the Printer Connection, so that when the gcode is uploaded to the printer, the filename can be used to allow for identifying the upload.

These changes should be backward compatible with the existing printer connection plugins, since the default behavior in PrinterConnectionBase is just to call the original loadGcode method, without the filename. Plugins that wish to take advantage of the additional information may do so by overriding the new loadGcode method instead of the original method.

This is to enable an OctoPrint Printer Connection Plugin that I am writting, since you can upload multiple gcode files to OctoPrint, and it is helpful to be able to identify the files after they have been uploaded.

https://github.com/scotthraban/octoprint-printer-connection-plugin-for-cura
