### PR TITLE
Added option for short time to use with gcode on small LCDs

### DIFF
--- a/Cura/gui/configWizard.py
+++ b/Cura/gui/configWizard.py
@@ -319,7 +319,7 @@ class PrintrbotPage(InfoPage):
 				if data[10]:
 					profile.setAlterationFile('start.gcode', """;Sliced at: {day} {date} {time}
 ;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-;Print time: {print_time}
+;Print time: {print_time}, short: {print_time_short}
 ;Filament used: {filament_amount}m {filament_weight}g
 ;Filament cost: {filament_cost}
 ;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line

--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -264,7 +264,7 @@ setting('object_center_y', -1, float, 'hidden', 'hidden')
 
 setting('start.gcode', """;Sliced at: {day} {date} {time}
 ;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-;Print time: {print_time}
+;Print time: {print_time}, short: {print_time_short}
 ;Filament used: {filament_amount}m {filament_weight}g
 ;Filament cost: {filament_cost}
 ;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -303,7 +303,7 @@ G90                         ;absolute positioning
 #######################################################################################
 setting('start2.gcode', """;Sliced at: {day} {date} {time}
 ;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-;Print time: {print_time}
+;Print time: {print_time}, short: {print_time_short}
 ;Filament used: {filament_amount}m {filament_weight}g
 ;Filament cost: {filament_cost}
 ;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -351,7 +351,7 @@ G90                         ;absolute positioning
 #######################################################################################
 setting('start3.gcode', """;Sliced at: {day} {date} {time}
 ;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-;Print time: {print_time}
+;Print time: {print_time}, short: {print_time_short}
 ;Filament used: {filament_amount}m {filament_weight}g
 ;Filament cost: {filament_cost}
 ;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -405,7 +405,7 @@ G90                         ;absolute positioning
 """, str, 'alteration', 'alteration')
 setting('start4.gcode', """;Sliced at: {day} {date} {time}
 ;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-;Print time: {print_time}
+;Print time: {print_time}, short: {print_time_short}
 ;Filament used: {filament_amount}m {filament_weight}g
 ;Filament cost: {filament_cost}
 ;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -1248,6 +1248,8 @@ def replaceTagMatch(m):
 		return pre + ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][int(time.strftime('%w'))]
 	if tag == 'print_time':
 		return pre + '#P_TIME#'
+	if tag == 'print_time_short':
+		return pre + '#P_TIME_SHORT#'
 	if tag == 'filament_amount':
 		return pre + '#F_AMNT#'
 	if tag == 'filament_weight':

--- a/Cura/util/sliceEngine.py
+++ b/Cura/util/sliceEngine.py
@@ -95,6 +95,13 @@ class EngineResult(object):
 			return _('%d hour %d minutes') % (int(self._printTimeSeconds / 60 / 60), int(self._printTimeSeconds / 60) % 60)
 		return _('%d hours %d minutes') % (int(self._printTimeSeconds / 60 / 60), int(self._printTimeSeconds / 60) % 60)
 
+	def getPrintTimeShort(self):
+		if self._printTimeSeconds is None:
+			return ''
+		if int(self._printTimeSeconds / 60 / 60) < 1:
+			return _('%dmin') % (int(self._printTimeSeconds / 60) % 60)
+		return _('%dh %dmin') % (int(self._printTimeSeconds / 60 / 60), int(self._printTimeSeconds / 60) % 60)
+
 	def getFilamentAmount(self, e=0):
 		if self._filamentMM[e] == 0.0:
 			return None
@@ -414,6 +421,7 @@ class Engine(object):
 			logThread.join()
 			if returnCode == 0:
 				self._result.addReplaceTag('#P_TIME#', self._result.getPrintTime())
+				self._result.addReplaceTag('#P_TIME_SHORT#', self._result.getPrintTimeShort())
 				self._result.addReplaceTag('#F_AMNT#', self._result.getFilamentAmountMeters(0))
 				self._result.addReplaceTag('#F_WGHT#', math.floor(self._result.getFilamentWeight(0) * 1000.0))
 				self._result.addReplaceTag('#F_COST#', self._result.getFilamentCost(0))

--- a/resources/machine_profiles/DeltaBot.ini
+++ b/resources/machine_profiles/DeltaBot.ini
@@ -22,7 +22,7 @@ travel_speed = 150
 [alterations]
 start.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -48,7 +48,7 @@ end.gcode = ;End GCode
 	G90                         ;absolute positioning
 start2.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line

--- a/resources/machine_profiles/Hephestos.ini
+++ b/resources/machine_profiles/Hephestos.ini
@@ -37,7 +37,7 @@ start.gcode =
 	; -- START GCODE --
 	;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;Uncomment to add your own temperature line

--- a/resources/machine_profiles/Hephestos_XL.ini
+++ b/resources/machine_profiles/Hephestos_XL.ini
@@ -37,7 +37,7 @@ start.gcode =
 	; -- START GCODE --
 	;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;Uncomment to add your own temperature line

--- a/resources/machine_profiles/RigidBot.ini
+++ b/resources/machine_profiles/RigidBot.ini
@@ -82,14 +82,14 @@ fix_horrible_union_all_type_a = True
 fix_horrible_union_all_type_b = False
 fix_horrible_use_open_bits = False
 fix_horrible_extensive_stitching = False
-plugin_config = 
+plugin_config =
 object_center_x = -1
 object_center_y = -1
 
 [alterations]
 start.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -121,7 +121,7 @@ end.gcode = ;End GCode
 	;{profile_string}
 start2.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -159,7 +159,7 @@ end2.gcode = ;End GCode
 	;{profile_string}
 start3.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -203,7 +203,7 @@ end3.gcode = ;End GCode
 	;{profile_string}
 start4.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -252,11 +252,11 @@ end4.gcode = ;End GCode
 	M84                         ;steppers off
 	G90                         ;absolute positioning
 	;{profile_string}
-support_start.gcode = 
-support_end.gcode = 
-cool_start.gcode = 
-cool_end.gcode = 
-replace.csv = 
+support_start.gcode =
+support_end.gcode =
+cool_start.gcode =
+cool_end.gcode =
+replace.csv =
 preswitchextruder.gcode = ;Switch between the current extruder and the next extruder, when printing with multiple extruders.
 	;This code is added before the T(n)
 postswitchextruder.gcode = ;Switch between the current extruder and the next extruder, when printing with multiple extruders.

--- a/resources/machine_profiles/RigidBotBig.ini
+++ b/resources/machine_profiles/RigidBotBig.ini
@@ -82,14 +82,14 @@ fix_horrible_union_all_type_a = True
 fix_horrible_union_all_type_b = False
 fix_horrible_use_open_bits = False
 fix_horrible_extensive_stitching = False
-plugin_config = 
+plugin_config =
 object_center_x = -1
 object_center_y = -1
 
 [alterations]
 start.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -121,7 +121,7 @@ end.gcode = ;End GCode
 	;{profile_string}
 start2.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -159,7 +159,7 @@ end2.gcode = ;End GCode
 	;{profile_string}
 start3.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line
@@ -203,7 +203,7 @@ end3.gcode = ;End GCode
 	;{profile_string}
 start4.gcode = ;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;M190 S{print_bed_temperature} ;Uncomment to add your own bed temperature line

--- a/resources/machine_profiles/Witbox.ini
+++ b/resources/machine_profiles/Witbox.ini
@@ -33,11 +33,11 @@ fan_enabled = True
 filament_flow = 100.0
 
 [alterations]
-start.gcode = 
+start.gcode =
 	; -- START GCODE --
 	;Sliced at: {day} {date} {time}
 	;Basic settings: Layer height: {layer_height} Walls: {wall_thickness} Fill: {fill_density}
-	;Print time: {print_time}
+	;Print time: {print_time}, short: {print_time_short}
 	;Filament used: {filament_amount}m {filament_weight}g
 	;Filament cost: {filament_cost}
 	;Uncomment to add your own temperature line
@@ -58,7 +58,7 @@ start.gcode =
 	;M117 Printing...
 	; -- end of START GCODE --
 
-end.gcode = 
+end.gcode =
 	; -- END GCODE --
 	M104 S0                 ;extruder heater off
 	M140 S0                 ;heated bed heater off (if you have it)


### PR DESCRIPTION
I am using Cura with a custom built RepRap, and I want to see the estimated print time on the screen. Since my LCD is quite small, the print time rarely fits on the screen. With this patch there's an option to use shorter time with {print_time_short}
