### PR TITLE
Replace direct calls to Nautilus and Dolphin with xdg-open

### DIFF
--- a/Cura/util/explorer.py
+++ b/Cura/util/explorer.py
@@ -13,9 +13,7 @@ def hasExplorer():
 	if sys.platform == 'win32' or sys.platform == 'cygwin' or sys.platform == 'darwin':
 		return True
 	if sys.platform == 'linux2':
-		if os.path.isfile('/usr/bin/nautilus'):
-			return True
-		if os.path.isfile('/usr/bin/dolphin'):
+		if os.path.isfile('/usr/bin/xdg-open'):
 			return True
 	return False
 
@@ -27,10 +25,8 @@ def openExplorer(filename):
 		subprocess.Popen(['open', '-R', filename])
 	if sys.platform.startswith('linux'):
 		#TODO: On linux we cannot seem to select a certain file, only open the specified path.
-		if os.path.isfile('/usr/bin/nautilus'):
-			subprocess.Popen(['/usr/bin/nautilus', os.path.split(filename)[0]])
-		elif os.path.isfile('/usr/bin/dolphin'):
-			subprocess.Popen(['/usr/bin/dolphin', os.path.split(filename)[0]])
+		if os.path.isfile('/usr/bin/xdg-open'):
+			subprocess.Popen(['/usr/bin/xdg-open', os.path.split(filename)[0]])
 
 def openExplorerPath(filename):
 	"""Open a file dialog inside a directory, without selecting any file."""
@@ -39,8 +35,6 @@ def openExplorerPath(filename):
 	if sys.platform == 'darwin':
 		subprocess.Popen(['open', filename])
 	if sys.platform.startswith('linux'):
-		if os.path.isfile('/usr/bin/nautilus'):
-			subprocess.Popen(['/usr/bin/nautilus', filename])
-		elif os.path.isfile('/usr/bin/dolphin'):
-			subprocess.Popen(['/usr/bin/dolphin', filename])
+		if os.path.isfile('/usr/bin/xdg-open'):
+			subprocess.Popen(['/usr/bin/xdg-open', filename])
 


### PR DESCRIPTION
This will still work in GNOME and KDE, but will also enable the functions for other Linux desktop environments, such as Xfce or MATE.

I believe that specifically checking for Nautilus and Dolphin is a bad idea, because it only covers a small amount of Linux users. xdg-open is exactly the mechanism supposed to be used for this kind of situations.

Relevant Fedora bug: [Open plugin location button doesn't work](https://bugzilla.redhat.com/show_bug.cgi?id=1217961)
