### PR TITLE
Prevent PyDeadObjectError

### DIFF
--- a/Cura/gui/app.py
+++ b/Cura/gui/app.py
@@ -134,6 +134,7 @@ class CuraApp(wx.App):
 			self.loadFiles = [exampleFile]
 			if self.splash is not None:
 				self.splash.Show(False)
+				self.splash = None
 			configWizard.ConfigWizard()
 
 		if profile.getPreference('check_for_updates') == 'True':
@@ -141,6 +142,7 @@ class CuraApp(wx.App):
 			if newVersion is not None:
 				if self.splash is not None:
 					self.splash.Show(False)
+					self.splash = None
 				if wx.MessageBox(_("A new version of Cura is available, would you like to download?"), _("New version available"), wx.YES_NO | wx.ICON_INFORMATION) == wx.YES:
 					webbrowser.open(newVersion)
 					return
@@ -149,6 +151,7 @@ class CuraApp(wx.App):
 		self.mainWindow = mainWindow.mainWindow()
 		if self.splash is not None:
 			self.splash.Show(False)
+			self.splash = None
 		self.SetTopWindow(self.mainWindow)
 		self.mainWindow.Show()
 		self.mainWindow.OnDropFiles(self.loadFiles)

--- a/Cura/gui/splashScreen.py
+++ b/Cura/gui/splashScreen.py
@@ -13,4 +13,5 @@ class splashScreen(wx.SplashScreen):
 
 	def DoCallback(self):
 		self.callback()
-		self.Destroy()
+		if self:
+			self.Destroy()


### PR DESCRIPTION
On wxPython 3, PyDeadObjectError exception was risen
when Cura was started for the first time.

This ensures it won't happen.

Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1230281
