### PR TITLE
Fix unnecessary auto-Raise() of toplevel window whenever it gets acti…

### DIFF
--- a/Cura/gui/app.py
+++ b/Cura/gui/app.py
@@ -79,9 +79,10 @@ class CuraApp(wx.App):
 		pass
 
 	def OnActivate(self, e):
-		if e.GetActive():
-			self.GetTopWindow().Raise()
-		e.Skip()
+		if sys.platform.startswith('darwin'):
+			if e.GetActive():
+				self.GetTopWindow().Raise()
+			e.Skip()
 
 	def Win32SocketListener(self, port):
 		import socket


### PR DESCRIPTION
…vated.

This is unnecessary (this is task of the window manager),
and actively annoying on focus-follows-mouse systems as the window
pops to the front on slight mouse over.

This is only needed to work around buggy behavior of the window
manager in OSX, so only activate it in that case.
