### PR TITLE
Fix for delta bots on newer Ubuntu

### DIFF
--- a/Cura/util/profile.py
+++ b/Cura/util/profile.py
@@ -1197,7 +1197,7 @@ def calculateObjectSizeOffsets():
 
 def getMachineCenterCoords():
 	if getMachineSetting('machine_center_is_zero') == 'True':
-		return [0, 0]
+		return [0.0, 0.0]
 	return [getMachineSettingFloat('machine_width') / 2, getMachineSettingFloat('machine_depth') / 2]
 
 #Returns a list of convex polygons, first polygon is the allowed area of the machine,


### PR DESCRIPTION
This fixes an issue on Ubuntu 16.04 where Cura won't slice for printers where the "Machine center 0,0" option is set.

Without this fix the slicing terminates with this message on stderr:

```
pos += (objMin + objMax) / 2.0 * 1000
```

TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
