### PR TITLE
Fix NumPy conversion for modern Ubuntu (16.04)

### DIFF
--- a/Cura/util/sliceEngine.py
+++ b/Cura/util/sliceEngine.py
@@ -343,7 +343,7 @@ class Engine(object):
 						objMax[1] = max(oMax[1], objMax[1])
 			if objMin is None:
 				return
-			pos += (objMin + objMax) / 2.0 * 1000
+                        pos = numpy.add( pos, (objMin + objMax) / 2.0 * 1000, out=pos, casting='unsafe')
 			commandList += ['-s', 'posx=%d' % int(pos[0]), '-s', 'posy=%d' % int(pos[1])]
 
 			vertexTotal = [0] * 4


### PR DESCRIPTION
Thanks to @gazhay who open the ticket #1461 and provided a simple solution.
Tested against fresh ubuntu 16.04 and old 14.04, with exact same slicing profiles, generated gcodes are identical and printing succeed.
